### PR TITLE
Code style cleanup

### DIFF
--- a/CustomTextEditor/editor.cpp
+++ b/CustomTextEditor/editor.cpp
@@ -340,7 +340,7 @@ void Editor::updateFileMetrics()
     for(int i = 0; i < documentLength; i++)
     {
         // Convert to unsigned char to avoid running into debug assertion problems
-        unsigned char currentCharacter = (unsigned char)documentContents[i].toLatin1();
+        unsigned char currentCharacter = qvariant_cast<unsigned char>(documentContents[i].toLatin1());
 
         // Newline
         if(currentCharacter == '\n')
@@ -360,7 +360,7 @@ void Editor::updateFileMetrics()
             // Alphanumeric character
             if(isalnum(currentCharacter))
             {
-                currentWord += (char)currentCharacter;
+                currentWord += qvariant_cast<char>(currentCharacter);
             }
             // Whitespace (excluding newline, handled separately above)
             else if(isspace(currentCharacter))
@@ -374,7 +374,8 @@ void Editor::updateFileMetrics()
                 // Consume all other instances of whitespace
                 else
                 {
-                    while(i + 1 < documentLength && isspace((unsigned char)documentContents[i + 1].toLatin1()))
+                    while(i + 1 < documentLength &&
+                          isspace(qvariant_cast<unsigned char>(documentContents[i + 1].toLatin1())))
                     {
                         i++;
                     }
@@ -681,8 +682,8 @@ void Editor::lineNumberAreaPaintEvent(QPaintEvent *event)
 
     QTextBlock block = firstVisibleBlock();
     int blockNumber = block.blockNumber();
-    int top = (int) blockBoundingGeometry(block).translated(contentOffset()).top();
-    int bottom = top + (int) blockBoundingRect(block).height();
+    int top = qvariant_cast<int>(blockBoundingGeometry(block).translated(contentOffset()).top());
+    int bottom = top + qvariant_cast<int>(blockBoundingRect(block).height());
 
     // Loop through each block (paragraph) and paint its corresponding number
     while (block.isValid() && top <= event->rect().bottom())
@@ -696,7 +697,7 @@ void Editor::lineNumberAreaPaintEvent(QPaintEvent *event)
 
         block = block.next();
         top = bottom;
-        bottom = top + (int) blockBoundingRect(block).height();
+        bottom = top + qvariant_cast<int>(blockBoundingRect(block).height());
         ++blockNumber;
     }
 }

--- a/CustomTextEditor/editor.h
+++ b/CustomTextEditor/editor.h
@@ -31,21 +31,26 @@ public:
     Editor(QWidget *parent = nullptr);
     ~Editor() override;
     void reset();
+
     inline QString getFileName() { return getFileNameFromPath(); }
     void setCurrentFilePath(QString newPath);
     inline QString getCurrentFilePath() const { return currentFilePath; }
     inline void setProgrammingLanguage(Language language) { programmingLanguage = language; }
     inline Language getProgrammingLanguage() const { return programmingLanguage; }
     inline bool isUntitled() const { return fileIsUntitled; }
+
     inline DocumentMetrics getDocumentMetrics() const { return metrics; }
     void launchFontDialog();
     void setFont(QString family, QFont::StyleHint styleHint, bool fixedPitch, int pointSize, int tabStopWidth);
     void updateFileMetrics();
+
     inline bool isUnsaved() const { return document()->isModified(); }
     void setModifiedState(bool modified) { document()->setModified(modified); }
+
     void formatSubtext(int startIndex, int endIndex, QTextCharFormat format, bool unformatAllFirst = false);
     void toggleAutoIndent(bool autoIndent) { autoIndentEnabled = autoIndent; }
     void toggleWrapMode(bool wrap) { wrap ? setLineWrapMode(LineWrapMode::WidgetWidth) : setLineWrapMode(LineWrapMode::NoWrap); }
+
     inline bool redoAvailable() const { return canRedo; }
     inline bool undoAvailable() const { return canUndo; }
 
@@ -73,6 +78,7 @@ private slots:
     void updateLineNumberAreaWidth();
     void on_cursorPositionChanged();
     void updateLineNumberArea(const QRect &rectToBeRedrawn, int numPixelsScrolledVertically);
+
     void setUndoAvailable(bool available) { canUndo = available; }
     void setRedoAvailable(bool available) { canRedo = available; }
 
@@ -80,6 +86,8 @@ private:
     QString getFileNameFromPath();
     QTextDocument::FindFlags getSearchOptionsFromFlags(bool caseSensitive, bool wholeWords);
     bool handleKeyPress(QObject* obj, QEvent* event, int key);
+    void moveCursorTo(int positionInText);
+
     int indentationLevelOfCurrentLine();
     void moveCursorToStartOfCurrentLine();
     void insertTabs(int numTabs);
@@ -88,11 +96,14 @@ private:
     DocumentMetrics metrics;
     QString currentFilePath;
     bool fileIsUntitled = true;
+
     QFont font;
     QTextCharFormat defaultCharFormat;
     SearchHistory searchHistory;
+
     QWidget *lineNumberArea;
     const int lineNumberAreaPadding = 30;
+
     bool metricCalculationEnabled = true;
     bool autoIndentEnabled = true;
     bool canRedo = false;

--- a/CustomTextEditor/utilityfunctions.h
+++ b/CustomTextEditor/utilityfunctions.h
@@ -3,12 +3,12 @@
 #include <QString>
 #include <QMessageBox>
 
-class Utility {
-public:
-    static QMessageBox::StandardButton promptYesOrNo(QWidget *parent, QString title, QString prompt);
-    static bool hasBalancedCurlyBraces(QString context);
-    static bool braceIsBalanced(QString context, int openBraceIndex);
-    static int indexOfFirstUnbalancedClosingBrace(QString context);
-};
+
+namespace Utility
+{
+    QMessageBox::StandardButton promptYesOrNo(QWidget *parent, QString title, QString prompt);
+    bool braceIsBalanced(QString context, int openBraceIndex);
+    int indexOfFirstUnbalancedClosingBrace(QString context);
+}
 
 #endif // UTILITYFUNCTIONS_H


### PR DESCRIPTION
- Changed the `Utility` class to a namespace; no need for it to be a class with static methods.

- Created a `moveCursorTo` function in the `Editor` class to avoid exposing messy `setTextCursor` logic in various functions.

- Resolve editor warnings by changing old-style manual casts to Qt-idiomatic casts.