### PR TITLE
Highlighter refactoring

### DIFF
--- a/CustomTextEditor/editor.cpp
+++ b/CustomTextEditor/editor.cpp
@@ -19,7 +19,7 @@ Editor::Editor(QWidget *parent) : QPlainTextEdit (parent)
     document()->setModified(false);
     setLineWrapMode(QPlainTextEdit::LineWrapMode::NoWrap);
 
-    programmingLanguage = Language::None;
+    setProgrammingLanguage(Language::None);
     metrics = DocumentMetrics();
     lineNumberArea = new LineNumberArea(this);
 
@@ -41,6 +41,7 @@ Editor::Editor(QWidget *parent) : QPlainTextEdit (parent)
 Editor::~Editor()
 {
     delete lineNumberArea;
+    delete syntaxHighlighter;
 }
 
 
@@ -115,6 +116,41 @@ void Editor::setFont(QString family, QFont::StyleHint styleHint, bool fixedPitch
 
     QFontMetrics metrics(font);
     setTabStopWidth(tabStopWidth * metrics.width(' '));
+}
+
+
+/* Sets this Editor's programming language to the given language.
+ * @param language - the language that this Editor should use for
+ * syntax highlighting
+ */
+void Editor::setProgrammingLanguage(Language language)
+{
+    if(language == this->programmingLanguage)
+    {
+        return;
+    }
+
+    this->programmingLanguage = language;
+    this->syntaxHighlighter = generateHighlighterFor(language);
+}
+
+
+/* Returns a Highlighter corresponding to the given language.
+ * @param language - the programming language for which a
+ * syntax highlighter should be generated
+ */
+Highlighter *Editor::generateHighlighterFor(Language language)
+{
+    QTextDocument *doc = document();
+
+    switch (language)
+    {
+        case(Language::C): return cHighlighter(doc);
+        case(Language::CPP): return cppHighlighter(doc);
+        case(Language::Java): return javaHighlighter(doc);
+        case(Language::Python): return pythonHighlighter(doc);
+        default: return nullptr;
+    }
 }
 
 

--- a/CustomTextEditor/editor.h
+++ b/CustomTextEditor/editor.h
@@ -5,6 +5,7 @@
 #include "searchhistory.h"
 #include "documentmetrics.h"
 #include "language.h"
+#include "highlighter.h"
 #include <QPlainTextEdit>
 #include <QFont>
 #include <QMessageBox>
@@ -35,7 +36,7 @@ public:
     inline QString getFileName() { return getFileNameFromPath(); }
     void setCurrentFilePath(QString newPath);
     inline QString getCurrentFilePath() const { return currentFilePath; }
-    inline void setProgrammingLanguage(Language language) { programmingLanguage = language; }
+    inline void setProgrammingLanguage(Language language);
     inline Language getProgrammingLanguage() const { return programmingLanguage; }
     inline bool isUntitled() const { return fileIsUntitled; }
 
@@ -83,6 +84,7 @@ private slots:
     void setRedoAvailable(bool available) { canRedo = available; }
 
 private:
+    Highlighter *generateHighlighterFor(Language language);
     QString getFileNameFromPath();
     QTextDocument::FindFlags getSearchOptionsFromFlags(bool caseSensitive, bool wholeWords);
     bool handleKeyPress(QObject* obj, QEvent* event, int key);
@@ -93,6 +95,8 @@ private:
     void insertTabs(int numTabs);
 
     Language programmingLanguage;
+    Highlighter *syntaxHighlighter;
+
     DocumentMetrics metrics;
     QString currentFilePath;
     bool fileIsUntitled = true;

--- a/CustomTextEditor/highlighter.cpp
+++ b/CustomTextEditor/highlighter.cpp
@@ -2,7 +2,7 @@
 #include <QtDebug>
 
 
-void Highlighter::setKeywords(QStringList keywords)
+void Highlighter::addKeywords(QStringList keywords)
 {
     setKeywordFormat();
 
@@ -131,7 +131,7 @@ void Highlighter::highlightMultilineComments(const QString &text)
 {
     setCurrentBlockState(BlockState::NotInComment);
 
-    qDebug() << "Previous state: " << previousBlockState();
+    // qDebug() << "Previous state: " << previousBlockState();
 
     int startIndex = 0;
 
@@ -192,7 +192,7 @@ Highlighter *cHighlighter(QTextDocument *doc)
     QRegularExpression blockCommentEnd("\\*/");
 
     Highlighter *highlighter = new Highlighter(doc);
-    highlighter->setKeywords(keywords);
+    highlighter->addKeywords(keywords);
     highlighter->setClassPattern(classPattern);
     highlighter->setQuotePattern(quotePattern);
     highlighter->setFunctionPattern(functionPattern);
@@ -208,42 +208,22 @@ Highlighter *cHighlighter(QTextDocument *doc)
  */
 Highlighter *cppHighlighter(QTextDocument *doc)
 {
-    QStringList keywords;
+    Highlighter *cLanguage = cHighlighter(doc);
+    QStringList cppOnlyKeywords;
 
-    keywords << "\\basm\\b" << "\\belse\\b" << "\\bnew\\b" << "\\bthis\\b" <<
-                "\\bauto\\b" << "\\benum\\b" << "\\boperator\\b" << "\\bthrow\\b" <<
-                "\\bbool\\b" << "\\bexplicit\\b" << "\\bprivate\\b" << "\\btrue\\b" <<
-                "\\bbreak\\b" << "\\bexport\\b" << "\\bprotected\\b" << "\\btry\\b" <<
-                "\\bcase\\b" << "\\bextern\\b" << "\\bpublic\\b" << "\\btypedef\\b" <<
-                "\\bcatch\\b" << "\\bfalse\\b" << "\\bregister\\b" << "\\btypeid\\b" <<
-                "\\bchar\\b" << "\\bfloat\\b" << "\\breinterpret_cast\\b" << "\\btypename\\b" <<
-                "\\bclass\\b" << "\\bfor\\b" << "\\breturn\\b" << "\\bunion\\b" <<
-                "\\bconst\\b" << "\\bfriend\\b" << "\\bshort\\b" << "\\bunsigned\\b" <<
-                "\\bconst_cast\\b" << "\\bgoto\\b" << "\\bsigned\\b" << "\\busing\\b" <<
-                "\\bcontinue\\b" << "\\bif\\b" << "\\bsizeof\\b" << "\\bvirtual\\b" <<
-                "\\bdefault\\b" << "\\binline\\b" << "\\bstatic\\b" << "\\bvoid\\b" <<
-                "\\bdelete\\b" << "\\bint\\b" << "\\bstatic_cast\\b" << "\\bvolatile\\b" <<
-                "\\bdo\\b" << "\\blong\\b" << "\\bstruct\\b" << "\\bwchar_t\\b" <<
-                "\\bdouble\\b" << "\\bmutable\\b" << "\\bswitch\\b" << "\\bwhile\\b" <<
-                "\\bdynamic_cast\\b" << "\\bnamespace\\b" << "\\btemplate\\b";
+    cppOnlyKeywords <<  "\\basm\\b" << "\\bbool\\b" << "\\bcatch\\b" <<
+                        "\\bclass\\b" << "\\bconst_cast\\b" << "\\bdelete\\b" <<
+                        "\\bdynamic_cast\\b" << "\\bexplicit\\b" << "\\bfalse\\b" <<
+                        "\\bfriend\\b" << "\\binline\\b" << "\\bmutable\\b" <<
+                        "\\bnamespace\\b" << "\\bnew\\b" << "\\boperator\\b" <<
+                        "\\bprivate\\b" << "\\bprotected\\b" << "\\bpublic\\b" <<
+                        "\\breinterpret_cast\\b" << "\\bstatic_cast\\b" <<
+                        "\\btemplate\\b" << "\\bthis\\b" << "\\bthrow\\b" <<
+                        "\\btrue\\b" << "\\btry\\b" << "\\btypeid\\b" << "\\btypename\\b" <<
+                        "\\bvirtual\\b" << "\\busing\\b" << "\\bwchar_t\\b";
 
-    QRegularExpression classPattern("\\b[A-Z_][a-zA-Z0-9_]*\\b");
-    QRegularExpression quotePattern("(\".*\")|('\\\\.')|('.{0,1}')");
-    QRegularExpression functionPattern("\\b[A-Za-z_][A-Za-z0-9_]*(?=\\()"); // TODO account for special operator overload cases
-    QRegularExpression inlineCommentPattern("//.*");
-    QRegularExpression blockCommentStart("/\\*");
-    QRegularExpression blockCommentEnd("\\*/");
-
-    Highlighter *highlighter = new Highlighter(doc);
-    highlighter->setKeywords(keywords);
-    highlighter->setClassPattern(classPattern);
-    highlighter->setQuotePattern(quotePattern);
-    highlighter->setFunctionPattern(functionPattern);
-    highlighter->setInlineCommentPattern(inlineCommentPattern);
-    highlighter->setBlockCommentStartPattern(blockCommentStart);
-    highlighter->setBlockCommentEndPattern(blockCommentEnd);
-
-    return highlighter;
+    cLanguage->addKeywords(cppOnlyKeywords);
+    return cLanguage;
 }
 
 
@@ -271,7 +251,7 @@ Highlighter *javaHighlighter(QTextDocument *doc)
     QRegularExpression blockCommentEnd("\\*/");
 
     Highlighter *highlighter = new Highlighter(doc);
-    highlighter->setKeywords(keywords);
+    highlighter->addKeywords(keywords);
     highlighter->setClassPattern(classPattern);
     highlighter->setQuotePattern(quotePattern);
     highlighter->setFunctionPattern(functionPattern);
@@ -305,7 +285,7 @@ Highlighter *pythonHighlighter(QTextDocument *doc)
     QRegularExpression blockCommentEnd("'''");
 
     Highlighter *highlighter = new Highlighter(doc);
-    highlighter->setKeywords(keywords);
+    highlighter->addKeywords(keywords);
     highlighter->setClassPattern(classPattern);
     highlighter->setQuotePattern(quotePattern);
     highlighter->setFunctionPattern(functionPattern);

--- a/CustomTextEditor/highlighter.cpp
+++ b/CustomTextEditor/highlighter.cpp
@@ -2,57 +2,103 @@
 #include <QtDebug>
 
 
-/* Constructs a Highlighter object using the given list of patterns and the parent
- * QTextDocument widget (nullptr by default).
- */
-Highlighter::Highlighter(QStringList keywordPatterns, QRegularExpression classPattern,
-                         QRegularExpression quotePattern, QRegularExpression functionPattern,
-                         QRegularExpression inlineCommentPattern, QRegularExpression blockCommentStart,
-                         QRegularExpression blockCommentEnd, QTextDocument *parent) : QSyntaxHighlighter (parent)
+void Highlighter::setKeywords(QStringList keywords)
 {
-    HighlightingRule rule;
+    setKeywordFormat();
 
-    // Class highlighting rule
-    classFormat.setFontWeight(QFont::Bold);
-    classFormat.setForeground(Qt::darkMagenta);
-    rule.pattern = classPattern;
-    rule.format = classFormat;
-    rules.append(rule);
+    foreach(const QString &keyword, keywords)
+    {
+        addRule(QRegularExpression(keyword), keywordFormat);
+    }
+}
 
+
+void Highlighter::setKeywordFormat()
+{
     keywordFormat.setForeground(Qt::darkBlue);
     keywordFormat.setFontWeight(QFont::Bold);
+}
 
-    // Create a HighlightingRule for each pattern and store it in the internal vector
-    foreach(const QString &pattern, keywordPatterns)
-    {
-        rule.pattern = QRegularExpression(pattern);
-        rule.format = keywordFormat;
-        rules.append(rule);
-    }
 
-    // Quotation (e.g., chars and strings) highlighting rule
-    quotationFormat.setForeground(Qt::darkGreen);
-    rule.pattern = quotePattern;
-    rule.format = quotationFormat;
-    rules.append(rule);
+void Highlighter::setClassPattern(QRegularExpression classPattern)
+{
+    setClassFormat();
+    addRule(classPattern, classFormat);
+}
 
-    // Functions
+
+void Highlighter::setClassFormat()
+{
+    classFormat.setFontWeight(QFont::Bold);
+    classFormat.setForeground(Qt::darkMagenta);
+}
+
+
+void Highlighter::setFunctionPattern(QRegularExpression functionPattern)
+{
+    setFunctionFormat();
+    addRule(functionPattern, functionFormat);
+}
+
+
+void Highlighter::setFunctionFormat()
+{
     functionFormat.setFontItalic(true);
     functionFormat.setForeground(Qt::blue);
-    rule.pattern = functionPattern;
-    rule.format = functionFormat;
-    rules.append(rule);
+}
 
-    // Inline comments
+
+void Highlighter::setQuotePattern(QRegularExpression quotePattern)
+{
+    setQuoteFormat();
+    addRule(quotePattern, quoteFormat);
+}
+
+
+void Highlighter::setQuoteFormat()
+{
+    quoteFormat.setForeground(Qt::darkGreen);
+}
+
+
+void Highlighter::setInlineCommentPattern(QRegularExpression inlineCommentPattern)
+{
+    setInlineCommentFormat();
+    addRule(inlineCommentPattern, inlineCommentFormat);
+}
+
+
+void Highlighter::setInlineCommentFormat()
+{
     inlineCommentFormat.setForeground(Qt::darkGreen);
-    rule.pattern = inlineCommentPattern;
-    rule.format = inlineCommentFormat;
-    rules.append(rule);
+}
 
-    // Block comments
-    blockCommentFormat.setForeground(Qt::darkGreen);
+
+void Highlighter::setBlockCommentStartPattern(QRegularExpression blockCommentStart)
+{
+    setBlockCommentFormat();
     this->blockCommentStart = blockCommentStart;
+}
+
+
+void Highlighter::setBlockCommentEndPattern(QRegularExpression blockCommentEnd)
+{
     this->blockCommentEnd = blockCommentEnd;
+}
+
+
+void Highlighter::setBlockCommentFormat()
+{
+    blockCommentFormat.setForeground(Qt::darkGreen);
+}
+
+
+void Highlighter::addRule(QRegularExpression pattern, QTextCharFormat format)
+{
+    HighlightingRule rule;
+    rule.pattern = pattern;
+    rule.format = format;
+    rules.append(rule);
 }
 
 
@@ -74,14 +120,14 @@ void Highlighter::highlightBlock(const QString &text)
         }
     }
 
-    formatMultilineComments(text);
+    highlightMultilineComments(text);
 }
 
 
 /* Formats multiline comments per this Highlighter's
  * blockCommentStart and blockCommentEnd patterns.
  */
-void Highlighter::formatMultilineComments(const QString &text)
+void Highlighter::highlightMultilineComments(const QString &text)
 {
     setCurrentBlockState(BlockState::NotInComment);
 
@@ -145,8 +191,16 @@ Highlighter *cHighlighter(QTextDocument *doc)
     QRegularExpression blockCommentStart("/\\*");
     QRegularExpression blockCommentEnd("\\*/");
 
-    return new Highlighter(keywords, classPattern, quotePattern, functionPattern,
-                           inlineCommentPattern, blockCommentStart, blockCommentEnd, doc);
+    Highlighter *highlighter = new Highlighter(doc);
+    highlighter->setKeywords(keywords);
+    highlighter->setClassPattern(classPattern);
+    highlighter->setQuotePattern(quotePattern);
+    highlighter->setFunctionPattern(functionPattern);
+    highlighter->setInlineCommentPattern(inlineCommentPattern);
+    highlighter->setBlockCommentStartPattern(blockCommentStart);
+    highlighter->setBlockCommentEndPattern(blockCommentEnd);
+
+    return highlighter;
 }
 
 
@@ -180,8 +234,16 @@ Highlighter *cppHighlighter(QTextDocument *doc)
     QRegularExpression blockCommentStart("/\\*");
     QRegularExpression blockCommentEnd("\\*/");
 
-    return new Highlighter(keywords, classPattern, quotePattern, functionPattern,
-                           inlineCommentPattern, blockCommentStart, blockCommentEnd, doc);
+    Highlighter *highlighter = new Highlighter(doc);
+    highlighter->setKeywords(keywords);
+    highlighter->setClassPattern(classPattern);
+    highlighter->setQuotePattern(quotePattern);
+    highlighter->setFunctionPattern(functionPattern);
+    highlighter->setInlineCommentPattern(inlineCommentPattern);
+    highlighter->setBlockCommentStartPattern(blockCommentStart);
+    highlighter->setBlockCommentEndPattern(blockCommentEnd);
+
+    return highlighter;
 }
 
 
@@ -208,8 +270,16 @@ Highlighter *javaHighlighter(QTextDocument *doc)
     QRegularExpression blockCommentStart("/\\*");
     QRegularExpression blockCommentEnd("\\*/");
 
-    return new Highlighter(keywords, classPattern, quotePattern, functionPattern,
-                           inlineCommentPattern, blockCommentStart, blockCommentEnd, doc);
+    Highlighter *highlighter = new Highlighter(doc);
+    highlighter->setKeywords(keywords);
+    highlighter->setClassPattern(classPattern);
+    highlighter->setQuotePattern(quotePattern);
+    highlighter->setFunctionPattern(functionPattern);
+    highlighter->setInlineCommentPattern(inlineCommentPattern);
+    highlighter->setBlockCommentStartPattern(blockCommentStart);
+    highlighter->setBlockCommentEndPattern(blockCommentEnd);
+
+    return highlighter;
 }
 
 
@@ -230,13 +300,20 @@ Highlighter *pythonHighlighter(QTextDocument *doc)
     QRegularExpression quotePattern("(\".*\")|('.*')");
     QRegularExpression functionPattern("\\b[A-Za-z_][A-Za-z0-9_]*(?=\\()");
     QRegularExpression inlineCommentPattern("#.*");
-
     // TODO change for Python
     QRegularExpression blockCommentStart("'''");
     QRegularExpression blockCommentEnd("'''");
 
-    return new Highlighter(keywords, classPattern, quotePattern, functionPattern,
-                           inlineCommentPattern, blockCommentStart, blockCommentEnd, doc);
+    Highlighter *highlighter = new Highlighter(doc);
+    highlighter->setKeywords(keywords);
+    highlighter->setClassPattern(classPattern);
+    highlighter->setQuotePattern(quotePattern);
+    highlighter->setFunctionPattern(functionPattern);
+    highlighter->setInlineCommentPattern(inlineCommentPattern);
+    highlighter->setBlockCommentStartPattern(blockCommentStart);
+    highlighter->setBlockCommentEndPattern(blockCommentEnd);
+
+    return highlighter;
 }
 
 

--- a/CustomTextEditor/highlighter.h
+++ b/CustomTextEditor/highlighter.h
@@ -8,14 +8,27 @@ class Highlighter : public QSyntaxHighlighter
     Q_OBJECT
 
 public:
-    Highlighter(QStringList keywordPatterns, QRegularExpression classPattern,
-                QRegularExpression quotePattern, QRegularExpression functionPattern,
-                QRegularExpression inlineCommentPattern, QRegularExpression blockCommentStart,
-                QRegularExpression blockCommentEnd, QTextDocument *parent = nullptr);
+
+    Highlighter(QTextDocument *parent = nullptr) : QSyntaxHighlighter (parent) {}
+    virtual void setKeywords(QStringList keywords);
+    virtual void setKeywordFormat();
+    virtual void setClassPattern(QRegularExpression classPattern);
+    virtual void setClassFormat();
+    virtual void setFunctionPattern(QRegularExpression functionPattern);
+    virtual void setFunctionFormat();
+    virtual void setQuotePattern(QRegularExpression quotePattern);
+    virtual void setQuoteFormat();
+    virtual void setInlineCommentPattern(QRegularExpression inlineCommentPattern);
+    virtual void setInlineCommentFormat();
+    virtual void setBlockCommentStartPattern(QRegularExpression blockCommentStart);
+    virtual void setBlockCommentEndPattern(QRegularExpression blockCommentEnd);
+    virtual void setBlockCommentFormat();
+    virtual void addRule(QRegularExpression pattern, QTextCharFormat format);
 
 protected:
-    void highlightBlock(const QString &text) override;
-    void formatMultilineComments(const QString &text);
+
+    virtual void highlightBlock(const QString &text) override;
+    virtual void highlightMultilineComments(const QString &text);
 
 private:
 
@@ -34,7 +47,7 @@ private:
     QTextCharFormat classFormat;
     QTextCharFormat inlineCommentFormat;
     QTextCharFormat blockCommentFormat;
-    QTextCharFormat quotationFormat;
+    QTextCharFormat quoteFormat;
     QTextCharFormat functionFormat;
 };
 
@@ -45,6 +58,9 @@ enum BlockState
     NotInComment,
     InComment
 };
+
+
+/* Used to build specific types of highlighters */
 
 Highlighter *cHighlighter(QTextDocument *doc);
 Highlighter *cppHighlighter(QTextDocument *doc);

--- a/CustomTextEditor/highlighter.h
+++ b/CustomTextEditor/highlighter.h
@@ -11,24 +11,25 @@ public:
 
     Highlighter(QTextDocument *parent = nullptr) : QSyntaxHighlighter (parent) {}
     virtual void addKeywords(QStringList keywords);
-    virtual void setKeywordFormat();
     virtual void setClassPattern(QRegularExpression classPattern);
-    virtual void setClassFormat();
     virtual void setFunctionPattern(QRegularExpression functionPattern);
-    virtual void setFunctionFormat();
     virtual void setQuotePattern(QRegularExpression quotePattern);
-    virtual void setQuoteFormat();
     virtual void setInlineCommentPattern(QRegularExpression inlineCommentPattern);
-    virtual void setInlineCommentFormat();
     virtual void setBlockCommentStartPattern(QRegularExpression blockCommentStart);
     virtual void setBlockCommentEndPattern(QRegularExpression blockCommentEnd);
-    virtual void setBlockCommentFormat();
     virtual void addRule(QRegularExpression pattern, QTextCharFormat format);
 
 protected:
 
     virtual void highlightBlock(const QString &text) override;
     virtual void highlightMultilineComments(const QString &text);
+
+    virtual void setKeywordFormat();
+    virtual void setClassFormat();
+    virtual void setFunctionFormat();
+    virtual void setQuoteFormat();
+    virtual void setInlineCommentFormat();
+    virtual void setBlockCommentFormat();
 
 private:
 

--- a/CustomTextEditor/highlighter.h
+++ b/CustomTextEditor/highlighter.h
@@ -15,8 +15,10 @@ public:
 
 protected:
     void highlightBlock(const QString &text) override;
+    void formatMultilineComments(const QString &text);
 
 private:
+
     struct HighlightingRule
     {
         QRegularExpression pattern;
@@ -36,6 +38,13 @@ private:
     QTextCharFormat functionFormat;
 };
 
+
+/* Used for multi-line comment formatting */
+enum BlockState
+{
+    NotInComment,
+    InComment
+};
 
 Highlighter *cHighlighter(QTextDocument *doc);
 Highlighter *cppHighlighter(QTextDocument *doc);

--- a/CustomTextEditor/highlighter.h
+++ b/CustomTextEditor/highlighter.h
@@ -10,7 +10,7 @@ class Highlighter : public QSyntaxHighlighter
 public:
 
     Highlighter(QTextDocument *parent = nullptr) : QSyntaxHighlighter (parent) {}
-    virtual void setKeywords(QStringList keywords);
+    virtual void addKeywords(QStringList keywords);
     virtual void setKeywordFormat();
     virtual void setClassPattern(QRegularExpression classPattern);
     virtual void setClassFormat();

--- a/CustomTextEditor/mainwindow.cpp
+++ b/CustomTextEditor/mainwindow.cpp
@@ -24,7 +24,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     languageGroup = new QActionGroup(this);
     languageGroup->setExclusive(true);
     languageGroup->addAction(ui->actionC_Lang);
-    languageGroup->addAction(ui->actionCPP);
+    languageGroup->addAction(ui->actionCPP_Lang);
     languageGroup->addAction(ui->actionJava_Lang);
     languageGroup->addAction(ui->actionPython_Lang);
     connect(languageGroup, SIGNAL(triggered(QAction*)), this, SLOT(on_languageSelected(QAction*)));
@@ -67,7 +67,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 void MainWindow::mapMenuLanguageOptionToLanguageType()
 {
     menuActionToLanguageMap[ui->actionC_Lang] = Language::C;
-    menuActionToLanguageMap[ui->actionCPP] = Language::CPP;
+    menuActionToLanguageMap[ui->actionCPP_Lang] = Language::CPP;
     menuActionToLanguageMap[ui->actionJava_Lang] = Language::Java;
     menuActionToLanguageMap[ui->actionPython_Lang] = Language::Python;
 }
@@ -126,9 +126,9 @@ void MainWindow::triggerCorrespondingMenuLanguageOption(Language lang)
             break;
 
         case(Language::CPP):
-            if(!ui->action_CPP->isChecked())
+            if(!ui->actionCPP_Lang->isChecked())
             {
-                ui->actionCPP->trigger();
+                ui->actionCPP_Lang->trigger();
             }
             break;
 

--- a/CustomTextEditor/mainwindow.cpp
+++ b/CustomTextEditor/mainwindow.cpp
@@ -43,6 +43,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 
     initializeStatusBarLabels();
     on_currentTab_changed(0);
+    selectProgrammingLanguage(Language::Python); // TODO delete
 
     // Connect tabbedEditor's signals to their handlers
     connect(tabbedEditor, SIGNAL(currentChanged(int)), this, SLOT(on_currentTab_changed(int)));

--- a/CustomTextEditor/mainwindow.cpp
+++ b/CustomTextEditor/mainwindow.cpp
@@ -43,7 +43,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 
     initializeStatusBarLabels();
     on_currentTab_changed(0);
-    selectProgrammingLanguage(Language::Python); // TODO delete
 
     // Connect tabbedEditor's signals to their handlers
     connect(tabbedEditor, SIGNAL(currentChanged(int)), this, SLOT(on_currentTab_changed(int)));
@@ -103,7 +102,7 @@ MainWindow::~MainWindow()
 
 
 /* Called when the user selects a language from the main menu. Sets the current language to
- * that language internally for the currently tabbed Editor and updates the syntax highlighter.
+ * that language internally for the currently tabbed Editor.
  */
 void MainWindow::on_languageSelected(QAction* languageAction)
 {
@@ -152,24 +151,6 @@ void MainWindow::triggerCorrespondingMenuLanguageOption(Language lang)
 }
 
 
-/* Calls the appropriate method to return a Highlighter object for the given language.
- * @param language - the language for which the Highlighter needs to be generated
- */
-Highlighter *MainWindow::generateHighlighterFor(Language language)
-{
-    QTextDocument *doc = editor->document();
-
-    switch (language)
-    {
-        case(Language::C): return cHighlighter(doc);
-        case(Language::CPP): return cppHighlighter(doc);
-        case(Language::Java): return javaHighlighter(doc);
-        case(Language::Python): return pythonHighlighter(doc);
-        default: return nullptr;
-    }
-}
-
-
 /* Uses the extension of a file to determine what language, if any, it should be
  * mapped to. If the extension does not match one of the supported languages, or if
  * the file does not have an extension, then the language is set to Language::None.
@@ -200,8 +181,7 @@ void MainWindow::setLanguageFromExtension()
 
 
 /* Wrapper for all common logic that needs to run whenever a given language
- * is selected for use on a particular tab. Generates an appropriate syntax
- * highlighter and triggers the corresponding menu option.
+ * is selected for use on a particular tab. Triggers the corresponding menu option.
  */
 void MainWindow::selectProgrammingLanguage(Language language)
 {
@@ -211,13 +191,6 @@ void MainWindow::selectProgrammingLanguage(Language language)
     }
 
     editor->setProgrammingLanguage(language);
-
-    if(syntaxHighlighter)
-    {
-        delete syntaxHighlighter;
-    }
-
-    syntaxHighlighter = generateHighlighterFor(language);
     languageLabel->setText(toString(language));
     triggerCorrespondingMenuLanguageOption(language);
 }
@@ -289,12 +262,10 @@ void MainWindow::on_currentTab_changed(int index)
 
     Language tabLanguage = editor->getProgrammingLanguage();
 
-    // If this tab had a programming language set, give it a syntax highlighter
+    // If this tab had a programming language set, trigger the corresponding option
     if(tabLanguage != Language::None)
     {
         triggerCorrespondingMenuLanguageOption(tabLanguage);
-        delete syntaxHighlighter;
-        syntaxHighlighter = generateHighlighterFor(tabLanguage);
     }
     else
     {        

--- a/CustomTextEditor/mainwindow.h
+++ b/CustomTextEditor/mainwindow.h
@@ -40,7 +40,6 @@ private:
     QMessageBox::StandardButton askUserToSave();
     void selectProgrammingLanguage(Language language);
     void triggerCorrespondingMenuLanguageOption(Language lang);
-    Highlighter *generateHighlighterFor(Language language);
     void mapMenuLanguageOptionToLanguageType();
     void mapFileExtensionsToLanguages();
     void setLanguageFromExtension();
@@ -50,7 +49,6 @@ private:
     Editor *editor = nullptr;
     FindDialog *findDialog;
     GotoDialog *gotoDialog;
-    Highlighter *syntaxHighlighter = nullptr;
     QActionGroup *languageGroup;
     QMap<QAction*, Language> menuActionToLanguageMap;
     QMap<QString, Language> extensionToLanguageMap;

--- a/CustomTextEditor/mainwindow.ui
+++ b/CustomTextEditor/mainwindow.ui
@@ -79,7 +79,7 @@
       <string>Language</string>
      </property>
      <addaction name="actionC_Lang"/>
-     <addaction name="actionCPP"/>
+     <addaction name="actionCPP_Lang"/>
      <addaction name="actionJava_Lang"/>
      <addaction name="actionPython_Lang"/>
     </widget>
@@ -259,14 +259,6 @@
     <string>Ctrl+F</string>
    </property>
   </action>
-  <action name="actionFind_Next">
-   <property name="text">
-    <string>Find Next</string>
-   </property>
-   <property name="shortcut">
-    <string>F3</string>
-   </property>
-  </action>
   <action name="actionReplace">
    <property name="text">
     <string>Replace...</string>
@@ -318,11 +310,6 @@
     <string>Status Bar</string>
    </property>
   </action>
-  <action name="actionAbout">
-   <property name="text">
-    <string>About</string>
-   </property>
-  </action>
   <action name="actionRedo">
    <property name="icon">
     <iconset>
@@ -355,63 +342,6 @@
     <string>Word Wrap</string>
    </property>
   </action>
-  <action name="actionC">
-   <property name="text">
-    <string>C</string>
-   </property>
-  </action>
-  <action name="actionC_2">
-   <property name="text">
-    <string>C++</string>
-   </property>
-  </action>
-  <action name="actionJava">
-   <property name="text">
-    <string>Java</string>
-   </property>
-  </action>
-  <action name="actionPython">
-   <property name="text">
-    <string>Python</string>
-   </property>
-  </action>
-  <action name="action_C">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>C</string>
-   </property>
-  </action>
-  <action name="action_CPP">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>C++</string>
-   </property>
-  </action>
-  <action name="action_Java">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Java</string>
-   </property>
-  </action>
-  <action name="action_Python">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Python</string>
-   </property>
-  </action>
-  <action name="actionC_3">
-   <property name="text">
-    <string>C</string>
-   </property>
-  </action>
   <action name="actionC_Lang">
    <property name="checkable">
     <bool>true</bool>
@@ -420,7 +350,7 @@
     <string>C</string>
    </property>
   </action>
-  <action name="actionCPP">
+  <action name="actionCPP_Lang">
    <property name="checkable">
     <bool>true</bool>
    </property>


### PR DESCRIPTION
Issue: #2 

Moved the Highlighter member from MainWindow to Editor.

Now, MainWindow no longer has to worry about whether the editor has a highligher set. Additionally, we don't have to waste memory and CPU time by regenerating a highlighter every time, since we can just short-circuit if the editor already has a language set.