### PR TITLE
Persist application settings after shutdown

### DIFF
--- a/CustomTextEditor/editor.cpp
+++ b/CustomTextEditor/editor.cpp
@@ -76,7 +76,7 @@ QString Editor::getFileNameFromPath()
         return "Untitled document";
     }
 
-    // Forward slash dependent on the OS, obviously
+    // Note on directories: Qt automatically converts Windows backslashes to forward slashes
     int indexOfLastForwardSlash = currentFilePath.lastIndexOf('/');
     int lengthOfFileName = currentFilePath.length() - indexOfLastForwardSlash;
 

--- a/CustomTextEditor/editor.cpp
+++ b/CustomTextEditor/editor.cpp
@@ -7,8 +7,7 @@
 #include <QTextDocumentFragment>
 #include <QPalette>
 #include <QStack>
-#include <QSet>
-#include <QQueue>
+#include <QFileInfo>
 #include <QtDebug>
 
 
@@ -76,12 +75,8 @@ QString Editor::getFileNameFromPath()
         return "Untitled document";
     }
 
-    // Note on directories: Qt automatically converts Windows backslashes to forward slashes
-    int indexOfLastForwardSlash = currentFilePath.lastIndexOf('/');
-    int lengthOfFileName = currentFilePath.length() - indexOfLastForwardSlash;
-
-    QString fileName = currentFilePath.mid(indexOfLastForwardSlash + 1, lengthOfFileName);
-    return fileName;
+    QFileInfo fileInfo(currentFilePath);
+    return fileInfo.fileName();
 }
 
 

--- a/CustomTextEditor/editor.h
+++ b/CustomTextEditor/editor.h
@@ -50,13 +50,18 @@ public:
 
     void formatSubtext(int startIndex, int endIndex, QTextCharFormat format, bool unformatAllFirst = false);
     void toggleAutoIndent(bool autoIndent) { autoIndentEnabled = autoIndent; }
-    void toggleWrapMode(bool wrap) { wrap ? setLineWrapMode(LineWrapMode::WidgetWidth) : setLineWrapMode(LineWrapMode::NoWrap); }
+    void toggleWrapMode(bool wrap);
 
     inline bool redoAvailable() const { return canRedo; }
     inline bool undoAvailable() const { return canUndo; }
 
     void lineNumberAreaPaintEvent(QPaintEvent *event);
     int getLineNumberAreaWidth();
+
+    void setLineWrapMode(LineWrapMode lineWrapMode);
+
+    static bool autoIndentEnabled;
+    static LineWrapMode lineWrapMode;
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -94,6 +99,9 @@ private:
     void moveCursorToStartOfCurrentLine();
     void insertTabs(int numTabs);
 
+    void writeSettings();
+    void readSettings();
+
     Language programmingLanguage;
     Highlighter *syntaxHighlighter;
 
@@ -109,9 +117,11 @@ private:
     const int lineNumberAreaPadding = 30;
 
     bool metricCalculationEnabled = true;
-    bool autoIndentEnabled = true;
     bool canRedo = false;
     bool canUndo = false;
+
+    const QString AUTO_INDENT_KEY = "auto_indent";
+    const QString LINE_WRAP_KEY = "line_wrap";
 };
 
 #endif // EDITOR_H

--- a/CustomTextEditor/main.cpp
+++ b/CustomTextEditor/main.cpp
@@ -1,9 +1,17 @@
 #include "mainwindow.h"
 #include <QApplication>
+#include <QtDebug>
+#include <QSysInfo>
+
 
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
+
+    app.setOrganizationName("Aleksandr Hovhannisyan");
+    app.setApplicationName("Scribe Text Editor");
+    app.setOrganizationDomain("aleksandrhovhannisyan.com");
+
     MainWindow window;
     QApplication::setStyle("fusion");
 

--- a/CustomTextEditor/mainwindow.cpp
+++ b/CustomTextEditor/mainwindow.cpp
@@ -19,7 +19,9 @@
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
+
     readSettings();
+    matchFormatOptionsToEditorDefaults();
 
     mapMenuLanguageOptionToLanguageType();
 
@@ -61,6 +63,19 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     QObject::connect(tabCloseShortcut, SIGNAL(activated()), this, SLOT(closeTabShortcut()));
 
     mapFileExtensionsToLanguages();
+}
+
+
+/* Ensures that the checkable formatting menu options, like auto indent
+ * and word wrap, match the previously saved defaults for the Editor class.
+ */
+void MainWindow::matchFormatOptionsToEditorDefaults()
+{
+    QAction *autoIndent = ui->actionAuto_Indent;
+    Editor::autoIndentEnabled ? autoIndent->setChecked(true) : autoIndent->setChecked(false);
+
+    QAction *wordWrap = ui->actionWord_Wrap;
+    Editor::lineWrapMode ? wordWrap->setChecked(true) : wordWrap->setChecked(false);
 }
 
 

--- a/CustomTextEditor/mainwindow.cpp
+++ b/CustomTextEditor/mainwindow.cpp
@@ -19,6 +19,7 @@
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
+    readSettings();
 
     mapMenuLanguageOptionToLanguageType();
 
@@ -601,7 +602,42 @@ void MainWindow::on_actionExit_triggered()
         }
     }
 
+    writeSettings();
     QApplication::quit();
+}
+
+
+/* Saves the main application state/settings so they may be
+ * restored the next time the application is started. See
+ * readSettings and the constructor for more info.
+ */
+void MainWindow::writeSettings()
+{
+    QSettings settings;
+    settings.setValue(WINDOW_SIZE_KEY, size());
+    settings.setValue(WINDOW_POSITION_KEY, pos());
+}
+
+
+/* Reads the stored app settings and restores them.
+ */
+void MainWindow::readSettings()
+{
+    QSettings settings;
+
+    QSize windowSize = settings.value(WINDOW_SIZE_KEY).toSize();
+
+    if(!windowSize.isNull())
+    {
+        resize(settings.value(WINDOW_SIZE_KEY, QSize(400, 400)).toSize());
+    }
+
+    QPoint windowPosition = settings.value(WINDOW_POSITION_KEY).toPoint();
+
+    if(!windowPosition.isNull())
+    {
+        move(settings.value(WINDOW_POSITION_KEY, QPoint(200, 200)).toPoint());
+    }
 }
 
 

--- a/CustomTextEditor/mainwindow.h
+++ b/CustomTextEditor/mainwindow.h
@@ -43,11 +43,16 @@ private:
     void mapMenuLanguageOptionToLanguageType();
     void mapFileExtensionsToLanguages();
     void setLanguageFromExtension();
+    void writeSettings();
+    void readSettings();
 
     Ui::MainWindow *ui;
     TabbedEditor *tabbedEditor;
     Editor *editor = nullptr;
 
+    // Used for storing application state upon termination
+    const QString WINDOW_SIZE_KEY = "window_size";
+    const QString WINDOW_POSITION_KEY = "window_position";
     const QString DEFAULT_DIRECTORY_KEY = "default_directory";
     const QString DEFAULT_DIRECTORY = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
 

--- a/CustomTextEditor/mainwindow.h
+++ b/CustomTextEditor/mainwindow.h
@@ -38,11 +38,14 @@ private:
     void reconnectEditorDependentSignals();
     void disconnectEditorDependentSignals();
     QMessageBox::StandardButton askUserToSave();
+
     void selectProgrammingLanguage(Language language);
     void triggerCorrespondingMenuLanguageOption(Language lang);
     void mapMenuLanguageOptionToLanguageType();
     void mapFileExtensionsToLanguages();
     void setLanguageFromExtension();
+
+    void matchFormatOptionsToEditorDefaults();
     void writeSettings();
     void readSettings();
 

--- a/CustomTextEditor/mainwindow.h
+++ b/CustomTextEditor/mainwindow.h
@@ -12,7 +12,7 @@
 #include <QCloseEvent>                  // closeEvent
 #include <QLabel>                       // GUI labels
 #include <QActionGroup>
-#include <QtDebug>
+#include <QStandardPaths>               // see default directory
 
 
 using namespace ProgrammingLanguage;
@@ -47,6 +47,10 @@ private:
     Ui::MainWindow *ui;
     TabbedEditor *tabbedEditor;
     Editor *editor = nullptr;
+
+    const QString DEFAULT_DIRECTORY_KEY = "default_directory";
+    const QString DEFAULT_DIRECTORY = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+
     FindDialog *findDialog;
     GotoDialog *gotoDialog;
     QActionGroup *languageGroup;


### PR DESCRIPTION
Issues: #16 , #15 

- Persist user's selected line wrap mode 
- Persist user's selected auto indentation mode
- Persist application window size and position

TODO: persist font.