### PR TITLE
Cleanup and minor bug fixes

### DIFF
--- a/CustomTextEditor/editor.cpp
+++ b/CustomTextEditor/editor.cpp
@@ -26,6 +26,7 @@ Editor::Editor(QWidget *parent) : QPlainTextEdit (parent)
     setProgrammingLanguage(Language::None);
     metrics = DocumentMetrics();
     lineNumberArea = new LineNumberArea(this);
+    setFont(QFont("Courier", DEFAULT_FONT_SIZE), QFont::Monospace, true, NUM_CHARS_FOR_TAB);
 
     connect(this, SIGNAL(blockCountChanged(int)), this, SLOT(updateLineNumberAreaWidth()));
     connect(this, SIGNAL(updateRequest(QRect,int)), this, SLOT(updateLineNumberArea(QRect,int)));
@@ -92,28 +93,26 @@ QString Editor::getFileNameFromPath()
 void Editor::launchFontDialog()
 {
     bool userChoseFont;
-    QFont font = QFontDialog::getFont(&userChoseFont, QFont("Courier", 10), this);
+    QFont newFont = QFontDialog::getFont(&userChoseFont, this->font, this);
 
     if(userChoseFont)
     {
-        setFont(font.family(), QFont::Monospace, true, font.pointSize(), 5);
+        setFont(newFont, QFont::Monospace, true, NUM_CHARS_FOR_TAB);
     }
 }
 
 
 /* Sets the editor's font using the specified parameters.
- * @param family - the name of the font family
+ * @param newFont - the font to be set
  * @param styleHint - used to select an appropriate default font family if the specified one is unavailable.
  * @param fixedPitch - if true, monospace font (equal-width characters)
- * @param pointSize - the size, in points, of the desired font (e.g., 12 for 12-pt font)
  * @param tabStopWidth - the desired width of a tab in terms of the equivalent number of spaces
  */
-void Editor::setFont(QString family, QFont::StyleHint styleHint, bool fixedPitch, int pointSize, int tabStopWidth)
+void Editor::setFont(QFont newFont, QFont::StyleHint styleHint, bool fixedPitch, int tabStopWidth)
 {
-    font.setFamily(family);
+    font = newFont;
     font.setStyleHint(styleHint);
     font.setFixedPitch(fixedPitch);
-    font.setPointSize(pointSize);
     QPlainTextEdit::setFont(font);
 
     QFontMetrics metrics(font);

--- a/CustomTextEditor/editor.cpp
+++ b/CustomTextEditor/editor.cpp
@@ -532,8 +532,7 @@ bool Editor::handleKeyPress(QObject* obj, QEvent* event, int key)
         QString documentContents = document()->toPlainText();
         int indexToLeftOfCursor = textCursor().position() - 1;
 
-        if(autoIndentEnabled &&
-           documentContents.length() >= 1 &&
+        if(documentContents.length() >= 1 &&
            indexToLeftOfCursor >= 0 &&
            indexToLeftOfCursor < documentContents.length())
         {
@@ -546,7 +545,7 @@ bool Editor::handleKeyPress(QObject* obj, QEvent* event, int key)
 
                 int braceLevel = indentationLevelOfCurrentLine();
                 insertPlainText("\n");
-                insertTabs(braceLevel + 1);
+                if(autoIndentEnabled) insertTabs(braceLevel + 1);
 
                 if(notPaired)
                 {
@@ -571,9 +570,17 @@ bool Editor::handleKeyPress(QObject* obj, QEvent* event, int key)
             // Hit ENTER after anything else
             else
             {
-                int indentationLevel = indentationLevelOfCurrentLine();
-                insertPlainText("\n");
-                insertTabs(indentationLevel);
+                if(autoIndentEnabled)
+                {
+                    int indentationLevel = indentationLevelOfCurrentLine();
+                    insertPlainText("\n");
+                    insertTabs(indentationLevel);
+                }
+                else
+                {
+                    insertPlainText("\n");
+                }
+
                 return true;
             }
         }

--- a/CustomTextEditor/editor.cpp
+++ b/CustomTextEditor/editor.cpp
@@ -38,13 +38,11 @@ Editor::Editor(QWidget *parent) : QPlainTextEdit (parent)
 
 
 /* Performs all necessary memory cleanup operations.
- * Saves editor settings for data persistence.
  */
 Editor::~Editor()
 {
     delete lineNumberArea;
     delete syntaxHighlighter;
-    writeSettings();
 }
 
 
@@ -353,9 +351,19 @@ void Editor::setLineWrapMode(LineWrapMode lineWrapMode)
 }
 
 
-/* Used by checkable menu options (see MainWindow) to toggle
- * the Editor's line wrap mode. That way, MainWindow does not
- * need to worry about what "true" and "false" correspond to.
+/* Used to toggle the Editor's auto indentation mode (on/off).
+ */
+void Editor::toggleAutoIndent(bool autoIndent)
+{
+    autoIndentEnabled = autoIndent;
+
+    // Update the setting in case any new tabs are opened later
+    writeSetting(AUTO_INDENT_KEY, autoIndentEnabled);
+}
+
+
+/* Used to toggle the Editor's line wrap mode (wrapping or no wrapping).
+ * @param wrap - flag denoting whether text should wrap (true) or not (false)
  */
 void Editor::toggleWrapMode(bool wrap)
 {
@@ -367,6 +375,9 @@ void Editor::toggleWrapMode(bool wrap)
     {
         setLineWrapMode(LineWrapMode::NoWrap);
     }
+
+    // Update the setting in case any new tabs are opened later
+    writeSetting(LINE_WRAP_KEY, lineWrapMode);
 }
 
 
@@ -628,14 +639,24 @@ bool Editor::eventFilter(QObject* obj, QEvent* event)
 }
 
 
+/* Convenience function used for writing a single setting.
+ * @param KEY - the string denoting the unique identifier for the setting
+ * @param VAL - the type to be written and associated with KEY
+ */
+void Editor::writeSetting(const QString KEY, QVariant VAL) const
+{
+    QSettings settings;
+    settings.setValue(KEY, VAL);
+}
+
+
 /* Preserves current settings for the editor so they can be
  * persisted into the next execution.
  */
 void Editor::writeSettings()
 {
-    QSettings settings;
-    settings.setValue(LINE_WRAP_KEY, lineWrapMode);
-    settings.setValue(AUTO_INDENT_KEY, autoIndentEnabled);
+    writeSetting(LINE_WRAP_KEY, lineWrapMode);
+    writeSetting(AUTO_INDENT_KEY, autoIndentEnabled);
 }
 
 

--- a/CustomTextEditor/editor.cpp
+++ b/CustomTextEditor/editor.cpp
@@ -88,20 +88,6 @@ QString Editor::getFileNameFromPath()
 }
 
 
-/* Launches a QFontDialog to allow the user to select a font.
- */
-void Editor::launchFontDialog()
-{
-    bool userChoseFont;
-    QFont newFont = QFontDialog::getFont(&userChoseFont, this->font, this);
-
-    if(userChoseFont)
-    {
-        setFont(newFont, QFont::Monospace, true, NUM_CHARS_FOR_TAB);
-    }
-}
-
-
 /* Sets the editor's font using the specified parameters.
  * @param newFont - the font to be set
  * @param styleHint - used to select an appropriate default font family if the specified one is unavailable.

--- a/CustomTextEditor/editor.cpp
+++ b/CustomTextEditor/editor.cpp
@@ -12,10 +12,6 @@
 #include <QSettings>
 
 
-bool Editor::autoIndentEnabled = true;
-Editor::LineWrapMode Editor::lineWrapMode = Editor::LineWrapMode::NoWrap;
-
-
 /* Initializes this Editor.
  */
 Editor::Editor(QWidget *parent) : QPlainTextEdit (parent)

--- a/CustomTextEditor/editor.cpp
+++ b/CustomTextEditor/editor.cpp
@@ -522,6 +522,28 @@ void Editor::moveCursorToStartOfCurrentLine()
 }
 
 
+/* Indents the selected text, if the cursor has a selection.
+ * Returns true if it succeeds and false otherwise.
+ */
+void Editor::indentSelection(QTextDocumentFragment selection)
+{
+    QString text = selection.toPlainText();
+
+    text.insert(0, '\t');
+    for(int i = 1; i < text.length(); i++)
+    {
+        // Insert a tab after each newline
+        if(text.at(i) == '\n' && i + 1 < text.length())
+        {
+            text.insert(i + 1, '\t');
+        }
+    }
+
+    // Replace the selection with the new tabbed text
+    insertPlainText(text);
+}
+
+
 /* Called when a user presses a key. Used to handle special formatting.
  */
 bool Editor::handleKeyPress(QObject* obj, QEvent* event, int key)
@@ -591,22 +613,11 @@ bool Editor::handleKeyPress(QObject* obj, QEvent* event, int key)
     {
         if(textCursor().hasSelection())
         {
-            QString text = textCursor().selection().toPlainText();
-
-            text.insert(0, '\t');
-            for(int i = 1; i < text.length(); i++)
-            {
-                // Insert a tab after each newline
-                if(text.at(i) == '\n' && i + 1 < text.length())
-                {
-                    text.insert(i + 1, '\t');
-                }
-            }
-
-            // Replace the selection with the new tabbed text
-            insertPlainText(text);
+            indentSelection(textCursor().selection());
             return true;
         }
+
+        return false;
     }
     // Process anything else normally
     else

--- a/CustomTextEditor/editor.h
+++ b/CustomTextEditor/editor.h
@@ -49,7 +49,7 @@ public:
     void setModifiedState(bool modified) { document()->setModified(modified); }
 
     void formatSubtext(int startIndex, int endIndex, QTextCharFormat format, bool unformatAllFirst = false);
-    void toggleAutoIndent(bool autoIndent) { autoIndentEnabled = autoIndent; }
+    void toggleAutoIndent(bool autoIndent);
     bool textIsAutoIndented() const { return autoIndentEnabled; }
     void toggleWrapMode(bool wrap);
     bool textIsWrapped() const { return lineWrapMode == LineWrapMode::WidgetWidth; }
@@ -104,6 +104,7 @@ private:
     void moveCursorToStartOfCurrentLine();
     void insertTabs(int numTabs);
 
+    void writeSetting(const QString KEY, QVariant VAL) const;
     void writeSettings();
     void readSettings();
 

--- a/CustomTextEditor/editor.h
+++ b/CustomTextEditor/editor.h
@@ -50,7 +50,9 @@ public:
 
     void formatSubtext(int startIndex, int endIndex, QTextCharFormat format, bool unformatAllFirst = false);
     void toggleAutoIndent(bool autoIndent) { autoIndentEnabled = autoIndent; }
+    bool textIsAutoIndented() const { return autoIndentEnabled; }
     void toggleWrapMode(bool wrap);
+    bool textIsWrapped() const { return lineWrapMode == LineWrapMode::WidgetWidth; }
 
     inline bool redoAvailable() const { return canRedo; }
     inline bool undoAvailable() const { return canUndo; }
@@ -62,8 +64,9 @@ public:
 
     const static int DEFAULT_FONT_SIZE = 10;
     const static int NUM_CHARS_FOR_TAB = 5;
-    static bool autoIndentEnabled;
-    static LineWrapMode lineWrapMode;
+
+    bool autoIndentEnabled = true;
+    LineWrapMode lineWrapMode = Editor::LineWrapMode::NoWrap;
 
 protected:
     void resizeEvent(QResizeEvent *event) override;

--- a/CustomTextEditor/editor.h
+++ b/CustomTextEditor/editor.h
@@ -103,6 +103,7 @@ private:
     int indentationLevelOfCurrentLine();
     void moveCursorToStartOfCurrentLine();
     void insertTabs(int numTabs);
+    void indentSelection(QTextDocumentFragment selection);
 
     void writeSetting(const QString KEY, QVariant VAL) const;
     void writeSettings();

--- a/CustomTextEditor/editor.h
+++ b/CustomTextEditor/editor.h
@@ -41,7 +41,7 @@ public:
     inline bool isUntitled() const { return fileIsUntitled; }
 
     inline DocumentMetrics getDocumentMetrics() const { return metrics; }
-    void launchFontDialog();
+    QFont getFont() { return font; }
     void setFont(QFont newFont, QFont::StyleHint styleHint, bool fixedPitch, int tabStopWidth);
     void updateFileMetrics();
 
@@ -60,6 +60,8 @@ public:
 
     void setLineWrapMode(LineWrapMode lineWrapMode);
 
+    const static int DEFAULT_FONT_SIZE = 10;
+    const static int NUM_CHARS_FOR_TAB = 5;
     static bool autoIndentEnabled;
     static LineWrapMode lineWrapMode;
 
@@ -110,9 +112,6 @@ private:
     bool fileIsUntitled = true;
 
     QFont font;
-    const int DEFAULT_FONT_SIZE = 10;
-    const int NUM_CHARS_FOR_TAB = 5;
-
     QTextCharFormat defaultCharFormat;
     SearchHistory searchHistory;
 

--- a/CustomTextEditor/editor.h
+++ b/CustomTextEditor/editor.h
@@ -42,7 +42,7 @@ public:
 
     inline DocumentMetrics getDocumentMetrics() const { return metrics; }
     void launchFontDialog();
-    void setFont(QString family, QFont::StyleHint styleHint, bool fixedPitch, int pointSize, int tabStopWidth);
+    void setFont(QFont newFont, QFont::StyleHint styleHint, bool fixedPitch, int tabStopWidth);
     void updateFileMetrics();
 
     inline bool isUnsaved() const { return document()->isModified(); }
@@ -110,6 +110,9 @@ private:
     bool fileIsUntitled = true;
 
     QFont font;
+    const int DEFAULT_FONT_SIZE = 10;
+    const int NUM_CHARS_FOR_TAB = 5;
+
     QTextCharFormat defaultCharFormat;
     SearchHistory searchHistory;
 

--- a/CustomTextEditor/finddialog.cpp
+++ b/CustomTextEditor/finddialog.cpp
@@ -1,7 +1,5 @@
 #include "finddialog.h"
 #include <QHBoxLayout>
-#include <QMessageBox>
-#include <QSplitter>
 
 
 /* Initializes this FindDialog object.
@@ -9,42 +7,14 @@
 FindDialog::FindDialog(QWidget *parent)
     : QDialog(parent)
 {
-    // Initialize all members
-    findLabel = new QLabel(tr("Find what:    "));
-    replaceLabel = new QLabel(tr("Replace with:"));
-    findLineEdit = new QLineEdit();
-    replaceLineEdit = new QLineEdit();
-    findNextButton = new QPushButton(tr("&Find next"));
-    replaceButton = new QPushButton(tr("&Replace"));
-    replaceAllButton = new QPushButton(tr("&Replace all"));
-    caseSensitiveCheckBox = new QCheckBox(tr("&Match case"));
-    wholeWordsCheckBox = new QCheckBox(tr("&Whole words"));
+    initializeWidgets();
 
     // Ensures that the line edit gets the focus whenever the dialog is the active window
     setFocusProxy(findLineEdit);
 
     // Set up all the widgets and layouts
-    findHorizontalLayout = new QHBoxLayout();
-    replaceHorizontalLayout = new QHBoxLayout();
-    optionsLayout = new QHBoxLayout();
-    verticalLayout = new QVBoxLayout();
+    initializeLayout();
 
-    verticalLayout->addLayout(findHorizontalLayout);
-    verticalLayout->addLayout(replaceHorizontalLayout);
-    verticalLayout->addLayout(optionsLayout);
-
-    findHorizontalLayout->addWidget(findLabel);
-    findHorizontalLayout->addWidget(findLineEdit);
-    replaceHorizontalLayout->addWidget(replaceLabel);
-    replaceHorizontalLayout->addWidget(replaceLineEdit);
-
-    optionsLayout->addWidget(caseSensitiveCheckBox);
-    optionsLayout->addWidget(wholeWordsCheckBox);
-    optionsLayout->addWidget(findNextButton);
-    optionsLayout->addWidget(replaceButton);
-    optionsLayout->addWidget(replaceAllButton);
-
-    setLayout(verticalLayout);
     setWindowTitle(tr("Find and Replace"));
 
     connect(findNextButton, SIGNAL(clicked()), this, SLOT(on_findNextButton_clicked()));
@@ -70,6 +40,51 @@ FindDialog::~FindDialog()
     delete replaceHorizontalLayout;
     delete optionsLayout;
     delete verticalLayout;
+}
+
+
+/* Initializes all child widgets, such as the labels, checkboxes, and buttons.
+ */
+void FindDialog::initializeWidgets()
+{
+    findLabel = new QLabel(tr("Find what:    "));
+    replaceLabel = new QLabel(tr("Replace with:"));
+    findLineEdit = new QLineEdit();
+    replaceLineEdit = new QLineEdit();
+    findNextButton = new QPushButton(tr("&Find next"));
+    replaceButton = new QPushButton(tr("&Replace"));
+    replaceAllButton = new QPushButton(tr("&Replace all"));
+    caseSensitiveCheckBox = new QCheckBox(tr("&Match case"));
+    wholeWordsCheckBox = new QCheckBox(tr("&Whole words"));
+}
+
+
+/* Defines this FindDialog's layout and adds the widgets
+ * to the appropriate child layouts.
+ */
+void FindDialog::initializeLayout()
+{
+    findHorizontalLayout = new QHBoxLayout();
+    replaceHorizontalLayout = new QHBoxLayout();
+    optionsLayout = new QHBoxLayout();
+    verticalLayout = new QVBoxLayout();
+
+    verticalLayout->addLayout(findHorizontalLayout);
+    verticalLayout->addLayout(replaceHorizontalLayout);
+    verticalLayout->addLayout(optionsLayout);
+
+    findHorizontalLayout->addWidget(findLabel);
+    findHorizontalLayout->addWidget(findLineEdit);
+    replaceHorizontalLayout->addWidget(replaceLabel);
+    replaceHorizontalLayout->addWidget(replaceLineEdit);
+
+    optionsLayout->addWidget(caseSensitiveCheckBox);
+    optionsLayout->addWidget(wholeWordsCheckBox);
+    optionsLayout->addWidget(findNextButton);
+    optionsLayout->addWidget(replaceButton);
+    optionsLayout->addWidget(replaceAllButton);
+
+    setLayout(verticalLayout);
 }
 
 

--- a/CustomTextEditor/finddialog.h
+++ b/CustomTextEditor/finddialog.h
@@ -32,6 +32,9 @@ public slots:
 
 private:
 
+    void initializeWidgets();
+    void initializeLayout();
+
     QLabel *findLabel;
     QLabel *replaceLabel;
     QPushButton *findNextButton;

--- a/CustomTextEditor/mainwindow.cpp
+++ b/CustomTextEditor/mainwindow.cpp
@@ -418,8 +418,6 @@ QMessageBox::StandardButton MainWindow::askUserToSave()
 void MainWindow::on_actionNew_triggered()
 {
     tabbedEditor->add(new Editor());
-    editor->toggleWrapMode(ui->actionWord_Wrap->isChecked());
-    editor->toggleAutoIndent(ui->actionAuto_Indent->isChecked());
 }
 
 

--- a/CustomTextEditor/mainwindow.h
+++ b/CustomTextEditor/mainwindow.h
@@ -79,8 +79,9 @@ public slots:
     void toggleUndo(bool undoAvailable);
     void toggleRedo(bool redoAvailable);
     void toggleCopyAndCut(bool copyCutAvailable);
-    bool closeTab(int index);
-    void closeTabShortcut() { closeTab(tabbedEditor->currentIndex()); }
+    bool closeTab(Editor *tabToClose);
+    bool closeTab(int index) { return closeTab(tabbedEditor->tabAt(index)); }
+    void closeTabShortcut() { closeTab(tabbedEditor->currentTab()); }
     inline void informUser(QString title, QString message) { QMessageBox::information(findDialog, title, message); }
 
 private slots:

--- a/CustomTextEditor/mainwindow.h
+++ b/CustomTextEditor/mainwindow.h
@@ -45,7 +45,9 @@ private:
     void mapFileExtensionsToLanguages();
     void setLanguageFromExtension();
 
+
     void matchFormatOptionsToEditorDefaults();
+    void updateFormatMenuOptions();
     void writeSettings();
     void readSettings();
 

--- a/CustomTextEditor/tabbededitor.cpp
+++ b/CustomTextEditor/tabbededitor.cpp
@@ -97,7 +97,6 @@ void TabbedEditor::promptFontSelection()
     {
         for (Editor *tab : tabs())
         {
-            qDebug() << "Setting font!";
             tab->setFont(newFont, QFont::Monospace, true, Editor::NUM_CHARS_FOR_TAB);
         }
     }
@@ -200,7 +199,7 @@ bool TabbedEditor::eventFilter(QObject* obj, QEvent* event)
             // Ctrl + num = jump to that tab number
             if(key >= Qt::Key_1 && key <= Qt::Key_9)
             {
-                setCurrentWidget(widget(key - Qt::Key_1));
+                setCurrentWidget(tabAt(key - Qt::Key_1));
                 return true;
             }
 
@@ -208,7 +207,7 @@ bool TabbedEditor::eventFilter(QObject* obj, QEvent* event)
             else if(key == Qt::Key_T)
             {
                 int newTabIndex = (currentIndex() + 1) % count();
-                setCurrentWidget(widget(newTabIndex));
+                setCurrentWidget(tabAt(newTabIndex));
                 return true;
             }
         }

--- a/CustomTextEditor/tabbededitor.cpp
+++ b/CustomTextEditor/tabbededitor.cpp
@@ -16,7 +16,6 @@ TabbedEditor::TabbedEditor(QWidget *parent) : QTabWidget(parent)
 void TabbedEditor::add(Editor *tab)
 {
     QTabWidget::addTab(tab, tab->getFileName());
-    tab->setFont("Courier", QFont::Monospace, true, 10, 5);
     setCurrentWidget(tab);
 }
 

--- a/CustomTextEditor/tabbededitor.cpp
+++ b/CustomTextEditor/tabbededitor.cpp
@@ -1,5 +1,9 @@
 #include "tabbededitor.h"
+#include "utilityfunctions.h"
+#include <QFont>
+#include <QFontDialog>
 #include <QtDebug>
+
 
 /* Initializes this TabbedEditor with a single Editor tab.
  */
@@ -17,6 +21,158 @@ void TabbedEditor::add(Editor *tab)
 {
     QTabWidget::addTab(tab, tab->getFileName());
     setCurrentWidget(tab);
+}
+
+
+/* Returns a pointer to the current Editor tab of this TabbedEditor.
+ */
+Editor* TabbedEditor::currentTab() const
+{
+    return qobject_cast<Editor*>(widget(currentIndex()));
+}
+
+
+/* Returns the tab at the specified index (0 to count() -1).
+ */
+Editor* TabbedEditor::tabAt(int index) const
+{
+    if(index < 0 || index >= count())
+    {
+        return nullptr;
+    }
+
+    return qobject_cast<Editor*>(widget(index));
+}
+
+
+/* Returns a vector of all Editor tabs this TabbedEditor contains.
+ */
+QVector<Editor*> TabbedEditor::tabs() const
+{
+    QVector<Editor*> tabs;
+
+    for(int i = 0; i < count(); i++)
+    {
+        tabs.push_back(tabAt(i));
+    }
+
+    return tabs;
+}
+
+
+/* Returns a vector of all Editor tabs that are unsaved.
+ */
+QVector<Editor*> TabbedEditor::unsavedTabs() const
+{
+    QVector<Editor*> unsavedTabs;
+
+    for(int i = 0; i < count(); i++)
+    {
+        Editor *tab = tabAt(i);
+
+        if(tab->isUnsaved())
+        {
+            unsavedTabs.push_back(tab);
+        }
+    }
+
+    return unsavedTabs;
+}
+
+
+/* Launches a QFontDialog to allow the user to select a font.
+ */
+void TabbedEditor::promptFontSelection()
+{
+    bool userChoseFont;
+    QFont newFont = QFontDialog::getFont(&userChoseFont, currentTab()->getFont(), this);
+
+    if(!userChoseFont) return;
+
+    QMessageBox::StandardButton tabSelection = Utility::promptYesOrNo(this, tr("Font change"),
+                                                                      tr("Apply to all tabs?"));
+
+    // Apply font to all tabs
+    if(tabSelection == QMessageBox::Yes)
+    {
+        for (Editor *tab : tabs())
+        {
+            qDebug() << "Setting font!";
+            tab->setFont(newFont, QFont::Monospace, true, Editor::NUM_CHARS_FOR_TAB);
+        }
+    }
+
+    // Apply font only to current tab
+    else if(tabSelection == QMessageBox::No)
+    {
+        currentTab()->setFont(newFont, QFont::Monospace, true, Editor::NUM_CHARS_FOR_TAB);
+    }
+
+    // If user hit cancel
+    else
+    {
+        return;
+    }
+}
+
+
+/* Applies word wrapping to either all tabs or the current tab, depending on the user's selection.
+ */
+void TabbedEditor::applyWordWrapping(bool shouldWrap)
+{
+    QMessageBox::StandardButton tabSelection = Utility::promptYesOrNo(this, tr("Word wrapping"),
+                                                                      tr("Apply to all tabs?"));
+
+    // Apply wrapping to all tabs
+    if(tabSelection == QMessageBox::Yes)
+    {
+        for (Editor *tab : tabs())
+        {
+            tab->toggleWrapMode(shouldWrap);
+        }
+    }
+
+    // Apply wrapping only to current tab
+    else if(tabSelection == QMessageBox::No)
+    {
+        currentTab()->toggleWrapMode(shouldWrap);
+    }
+
+    // If user hit cancel
+    else
+    {
+        return;
+    }
+}
+
+
+/* Applies auto indentation to either all tabs or the current tab, depending on the user's selection.
+ */
+void TabbedEditor::applyAutoIndentation(bool shouldAutoIndent)
+{
+    QMessageBox::StandardButton tabSelection = Utility::promptYesOrNo(this, tr("Auto indentation"),
+                                                                      tr("Apply to all tabs?"));
+
+    // Apply auto indentation to all tabs
+    if(tabSelection == QMessageBox::Yes)
+    {
+        for (Editor *tab : tabs())
+        {
+            tab->toggleAutoIndent(shouldAutoIndent);
+        }
+    }
+
+    // Apply auto indentation only to current tab
+    else if(tabSelection == QMessageBox::No)
+    {
+        currentTab()->toggleAutoIndent(shouldAutoIndent);
+    }
+
+    // If user hit cancel
+    else
+    {
+        return;
+    }
 }
 
 

--- a/CustomTextEditor/tabbededitor.cpp
+++ b/CustomTextEditor/tabbededitor.cpp
@@ -118,7 +118,7 @@ void TabbedEditor::promptFontSelection()
 
 /* Applies word wrapping to either all tabs or the current tab, depending on the user's selection.
  */
-void TabbedEditor::applyWordWrapping(bool shouldWrap)
+bool TabbedEditor::applyWordWrapping(bool shouldWrap)
 {
     QMessageBox::StandardButton tabSelection = Utility::promptYesOrNo(this, tr("Word wrapping"),
                                                                       tr("Apply to all tabs?"));
@@ -130,25 +130,29 @@ void TabbedEditor::applyWordWrapping(bool shouldWrap)
         {
             tab->toggleWrapMode(shouldWrap);
         }
+
+        return true;
     }
 
     // Apply wrapping only to current tab
     else if(tabSelection == QMessageBox::No)
     {
         currentTab()->toggleWrapMode(shouldWrap);
+        return true;
     }
 
     // If user hit cancel
     else
     {
-        return;
+        return false;
     }
 }
 
 
 /* Applies auto indentation to either all tabs or the current tab, depending on the user's selection.
+ * Returns true if the formatting was applied at all, and false if the operation was canceled.
  */
-void TabbedEditor::applyAutoIndentation(bool shouldAutoIndent)
+bool TabbedEditor::applyAutoIndentation(bool shouldAutoIndent)
 {
     QMessageBox::StandardButton tabSelection = Utility::promptYesOrNo(this, tr("Auto indentation"),
                                                                       tr("Apply to all tabs?"));
@@ -160,18 +164,21 @@ void TabbedEditor::applyAutoIndentation(bool shouldAutoIndent)
         {
             tab->toggleAutoIndent(shouldAutoIndent);
         }
+
+        return true;
     }
 
     // Apply auto indentation only to current tab
     else if(tabSelection == QMessageBox::No)
     {
         currentTab()->toggleAutoIndent(shouldAutoIndent);
+        return true;
     }
 
     // If user hit cancel
     else
     {
-        return;
+        return false;
     }
 }
 

--- a/CustomTextEditor/tabbededitor.h
+++ b/CustomTextEditor/tabbededitor.h
@@ -2,14 +2,25 @@
 #define TABBEDEDITOR_H
 #include <QTabWidget>
 #include <editor.h>
+#include <QVector>
 
 class TabbedEditor : public QTabWidget
 {
     Q_OBJECT
 
 public:
+
     TabbedEditor(QWidget *parent = nullptr);
     void add(Editor* tab);
+
+    Editor *currentTab() const;
+    Editor *tabAt(int index) const;
+    QVector<Editor*> tabs() const;
+    QVector<Editor*> unsavedTabs() const;
+
+    void promptFontSelection();
+    void applyWordWrapping(bool shouldWrap);
+    void applyAutoIndentation(bool shouldAutoIndent);
 
 protected:
     bool eventFilter(QObject* obj, QEvent* event) override;

--- a/CustomTextEditor/tabbededitor.h
+++ b/CustomTextEditor/tabbededitor.h
@@ -19,8 +19,8 @@ public:
     QVector<Editor*> unsavedTabs() const;
 
     void promptFontSelection();
-    void applyWordWrapping(bool shouldWrap);
-    void applyAutoIndentation(bool shouldAutoIndent);
+    bool applyWordWrapping(bool shouldWrap);
+    bool applyAutoIndentation(bool shouldAutoIndent);
 
 protected:
     bool eventFilter(QObject* obj, QEvent* event) override;


### PR DESCRIPTION
- Get rid of some magic numbers with regard to font code (e.g., default font size, number of characters that equal a tab, etc.)

- Get rid of the font selection/dialog code from the Editor; move that over to TabbedEditor so it can ask the user whether it should apply the font to all tabs or just the current tab.

- Allow TabbedEditor to also apply word wrapping and auto indentation to all open tabs or just the current one, depending on the user's selection.

- Introduce new utility functions to TabbedEditor for retrieving certain tabs: the current tab, all tabs, a tab at a specified index, or all unsaved tabs. This greatly simplifies the logic in MainWindow and eliminates MainWindow's overreliance on the `widget` function. (Related issue: #21)

- Fix some of the logic for preserving auto indentation and word wrapping, in light of changes above that allow this formatting to be applied selectively or to all open tabs. Any time a change is made to one of these formatting options, it will get written to the settings so it can be loaded immediately as soon as a new tab is created.

- Clean up some other code to make it simpler to read. Fix minor bugs.