### PR TITLE
Fix bug that prevented column count from updating on tab change

### DIFF
--- a/CustomTextEditor/editor.cpp
+++ b/CustomTextEditor/editor.cpp
@@ -389,7 +389,10 @@ void Editor::updateFileMetrics()
 {
     QString documentContents = toPlainText().toUtf8();
     int documentLength = documentContents.length();
+
+    DocumentMetrics oldMetrics = metrics;
     metrics = DocumentMetrics();
+    metrics.currentColumn = oldMetrics.currentColumn;
     QString currentWord = "";
 
     // Loop through each character in the document

--- a/CustomTextEditor/mainwindow.cpp
+++ b/CustomTextEditor/mainwindow.cpp
@@ -235,6 +235,9 @@ void MainWindow::disconnectEditorDependentSignals()
     disconnect(findDialog, SIGNAL(startReplacingAll(QString, QString, bool, bool)), editor, SLOT(replaceAll(QString, QString, bool, bool)));
     disconnect(gotoDialog, SIGNAL(gotoLine(int)), editor, SLOT(goTo(int)));
 
+    disconnect(editor, SIGNAL(columnCountChanged(int)), this, SLOT(updateColumnCount(int)));
+    disconnect(editor, SIGNAL(windowNeedsToBeUpdated(DocumentMetrics)), this, SLOT(updateWordAndCharCount(DocumentMetrics)));
+    disconnect(editor, SIGNAL(windowNeedsToBeUpdated(DocumentMetrics)), this, SLOT(updateTabAndWindowTitle()));
     disconnect(editor, SIGNAL(findResultReady(QString)), findDialog, SLOT(onFindResultReady(QString)));
     disconnect(editor, SIGNAL(gotoResultReady(QString)), gotoDialog, SLOT(onGotoResultReady(QString)));
     disconnect(editor, SIGNAL(undoAvailable(bool)), this, SLOT(toggleUndo(bool)));
@@ -281,12 +284,11 @@ void MainWindow::on_currentTab_changed(int index)
     // Note: editor will only be nullptr on the first launch, so this will get skipped in that edge case
     if(editor != nullptr)
     {
-        // Disconnect for previous active editor
         disconnectEditorDependentSignals();
     }
 
-    // Set the internal editor to the currently tabbed one
     editor = tabbedEditor->currentTab();
+    reconnectEditorDependentSignals();
     editor->setFocus(Qt::FocusReason::TabFocusReason);
 
     Language tabLanguage = editor->getProgrammingLanguage();
@@ -314,7 +316,7 @@ void MainWindow::on_currentTab_changed(int index)
     toggleCopyAndCut(editor->textCursor().hasSelection());
 
     updateFormatMenuOptions();
-    reconnectEditorDependentSignals();
+
 
     // This info only gets passed on by Editor when its contents change, not when a new tab is added to TabbedEditor
     DocumentMetrics metrics = editor->getDocumentMetrics();


### PR DESCRIPTION
Related issue: #25 

When recalculating file metrics in `editor.cpp`, I was resetting the metrics via `metrics = DocumentMetrics()` and not realizing that this was resetting the column count as a side effect. Since the method that was doing this was not responsible for also updating the column count, it was resetting the column count to 1, and MainWindow was picking up that number instead of the old one.