### PR TITLE
Extract metric reporting into its own class and give MainWindow an instance of it.

### DIFF
--- a/CustomTextEditor/CustomTextEditor.pro
+++ b/CustomTextEditor/CustomTextEditor.pro
@@ -29,6 +29,7 @@ SOURCES += \
         mainwindow.cpp \
         finddialog.cpp \
     editor.cpp \
+    metricreporter.cpp \
     utilityfunctions.cpp \
     searchhistory.cpp \
     gotodialog.cpp \
@@ -42,6 +43,7 @@ HEADERS += \
         finddialog.h \
     editor.h \
     linenumberarea.h \
+    metricreporter.h \
     utilityfunctions.h \
     searchhistory.h \
     gotodialog.h \

--- a/CustomTextEditor/mainwindow.h
+++ b/CustomTextEditor/mainwindow.h
@@ -7,6 +7,7 @@
 #include "gotodialog.h"
 #include "tabbededitor.h"
 #include "language.h"
+#include "metricreporter.h"
 #include <highlighter.h>
 #include <QMainWindow>
 #include <QCloseEvent>                  // closeEvent
@@ -29,7 +30,6 @@ class MainWindow : public QMainWindow
 public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow() override;
-    void initializeStatusBarLabels();
     void launchFindDialog();
     void launchGotoDialog();
     void closeEvent(QCloseEvent *event) override;
@@ -39,6 +39,7 @@ private:
     void disconnectEditorDependentSignals();
     QMessageBox::StandardButton askUserToSave();
 
+    void setupLanguageOnStatusBar();
     void selectProgrammingLanguage(Language language);
     void triggerCorrespondingMenuLanguageOption(Language lang);
     void mapMenuLanguageOptionToLanguageType();
@@ -53,6 +54,7 @@ private:
     // The "core" or essential members
     Ui::MainWindow *ui;
     TabbedEditor *tabbedEditor;
+    MetricReporter *metricReporter;
     Editor *editor = nullptr;
 
     // Used for storing application state upon termination
@@ -66,30 +68,16 @@ private:
     FindDialog *findDialog;
     GotoDialog *gotoDialog;
     QActionGroup *languageGroup;
+    QLabel *languageLabel;
     QMap<QAction*, Language> menuActionToLanguageMap;
     QMap<QString, Language> extensionToLanguageMap;
 
-    QLabel *languageLabel;
-    QLabel *wordLabel;
-    QLabel *wordCountLabel;
-    QLabel *lineLabel;
-    QLabel *lineCountLabel;
-    QLabel *charLabel;
-    QLabel *charCountLabel;
-    QLabel *columnLabel;
-    QLabel *columnCountLabel;
-
 public slots:
-    void updateWordCount(int wordCount);
-    void updateCharCount(int charCount);
-    void updateLineCount(int current, int total);
-    void updateColumnCount(int columnCount);
-    void updateTabAndWindowTitle();
-
     void toggleUndo(bool undoAvailable);
     void toggleRedo(bool redoAvailable);
     void toggleCopyAndCut(bool copyCutAvailable);
 
+    void updateTabAndWindowTitle();
     bool closeTab(Editor *tabToClose);
     bool closeTab(int index) { return closeTab(tabbedEditor->tabAt(index)); }
     void closeTabShortcut() { closeTab(tabbedEditor->currentTab()); }

--- a/CustomTextEditor/metricreporter.cpp
+++ b/CustomTextEditor/metricreporter.cpp
@@ -1,0 +1,59 @@
+#include "metricreporter.h"
+
+
+MetricReporter::MetricReporter(QWidget *parent) : QFrame(parent)
+{
+    // Note: since all of these get added as widgets, they will be
+    // deallocated automatically by the QSplitter destructor
+    wordLabel = new QLabel("Words: ");
+    wordCountLabel = new QLabel();
+    charLabel = new QLabel("Chars: ");
+    charCountLabel = new QLabel();
+    lineLabel = new QLabel("Line: ");
+    lineCountLabel = new QLabel();
+    columnLabel = new QLabel("Column: ");
+    columnCountLabel = new QLabel();
+
+    QHBoxLayout *layout = new QHBoxLayout();
+    layout->addWidget(wordLabel);
+    layout->addWidget(wordCountLabel);
+    layout->addWidget(charLabel);
+    layout->addWidget(charCountLabel);
+    layout->addWidget(lineLabel);
+    layout->addWidget(lineCountLabel);
+    layout->addWidget(columnLabel);
+    layout->addWidget(columnCountLabel);
+    setLayout(layout);
+}
+
+
+/* Updates the word count using the associated label.
+ */
+void MetricReporter::updateWordCount(int wordCount)
+{
+    wordCountLabel->setText(QString::number(wordCount));
+}
+
+
+/* Updates the char count using the associated label.
+ */
+void MetricReporter::updateCharCount(int charCount)
+{
+    charCountLabel->setText(QString::number(charCount));
+}
+
+
+/* Updates the line count using the associated label.
+ */
+void MetricReporter::updateLineCount(int current, int total)
+{
+    lineCountLabel->setText(QString::number(current) + tr("/") + QString::number(total));
+}
+
+
+/* Updates the column count using the associated label.
+ */
+void MetricReporter::updateColumnCount(int columnCount)
+{
+    columnCountLabel->setText(QString::number(columnCount));
+}

--- a/CustomTextEditor/metricreporter.h
+++ b/CustomTextEditor/metricreporter.h
@@ -1,0 +1,33 @@
+#ifndef METRICREPORTER_H
+#define METRICREPORTER_H
+#include <QSplitter>
+#include <QLabel>
+#include <QGroupBox>
+#include <QHBoxLayout>
+
+
+class MetricReporter : public QFrame
+{
+    Q_OBJECT
+
+public:
+    explicit MetricReporter(QWidget *parent = nullptr);
+
+public slots:
+    void updateWordCount(int wordCount);
+    void updateCharCount(int charCount);
+    void updateLineCount(int current, int total);
+    void updateColumnCount(int columnCount);
+
+private:
+    QLabel *wordLabel;
+    QLabel *wordCountLabel;
+    QLabel *lineLabel;
+    QLabel *lineCountLabel;
+    QLabel *charLabel;
+    QLabel *charCountLabel;
+    QLabel *columnLabel;
+    QLabel *columnCountLabel;
+};
+
+#endif // METRICREPORTER_H


### PR DESCRIPTION
Related issue: #31 

Extracted the labels and made them part of a QFrame that has a horizontal layout.

![image](https://user-images.githubusercontent.com/19352442/58754777-a0937780-84a5-11e9-8e17-c7c93a203dc7.png)

Appearance is mostly unchanged, save for some padding that got added (which actually looks much better). I also added the language label as part of a frame, which gave it the same padding for consistency.

![image](https://user-images.githubusercontent.com/19352442/58754782-af7a2a00-84a5-11e9-9f93-43d25fa05aa5.png)
