### PR TITLE
Make tabs movable

### DIFF
--- a/CustomTextEditor/tabbededitor.cpp
+++ b/CustomTextEditor/tabbededitor.cpp
@@ -11,6 +11,7 @@ TabbedEditor::TabbedEditor(QWidget *parent) : QTabWidget(parent)
 {
     add(new Editor());
     installEventFilter(this);
+    setMovable(true);
 }
 
 


### PR DESCRIPTION
Apparently the tabs are set to not movable by default in the `QTabWidget` class. I enabled them with `setMovable(true)` in `TabbedEditor`'s constructor.