### PR TITLE
Minor cleanup

### DIFF
--- a/CustomTextEditor/editor.cpp
+++ b/CustomTextEditor/editor.cpp
@@ -75,7 +75,7 @@ void Editor::setCurrentFilePath(QString newPath)
  */
 QString Editor::getFileNameFromPath()
 {
-    if(currentFilePath.isEmpty())
+    if (currentFilePath.isEmpty())
     {
         fileIsUntitled = true;
         return "Untitled document";
@@ -110,7 +110,7 @@ void Editor::setFont(QFont newFont, QFont::StyleHint styleHint, bool fixedPitch,
  */
 void Editor::setProgrammingLanguage(Language language)
 {
-    if(language == this->programmingLanguage)
+    if (language == this->programmingLanguage)
     {
         return;
     }
@@ -130,10 +130,10 @@ Highlighter *Editor::generateHighlighterFor(Language language)
 
     switch (language)
     {
-        case(Language::C): return new CHighlighter(doc);
-        case(Language::CPP): return new CPPHighlighter(doc);
-        case(Language::Java): return new JavaHighlighter(doc);
-        case(Language::Python): return new PythonHighlighter(doc);
+        case (Language::C): return new CHighlighter(doc);
+        case (Language::CPP): return new CPPHighlighter(doc);
+        case (Language::Java): return new JavaHighlighter(doc);
+        case (Language::Python): return new PythonHighlighter(doc);
         default: return nullptr;
     }
 }
@@ -146,11 +146,11 @@ Highlighter *Editor::generateHighlighterFor(Language language)
 QTextDocument::FindFlags Editor::getSearchOptionsFromFlags(bool caseSensitive, bool wholeWords)
 {
     QTextDocument::FindFlags searchOptions = QTextDocument::FindFlags();
-    if(caseSensitive)
+    if (caseSensitive)
     {
         searchOptions |= QTextDocument::FindCaseSensitively;
     }
-    if(wholeWords)
+    if (wholeWords)
     {
         searchOptions |= QTextDocument::FindWholeWords;
     }
@@ -179,21 +179,21 @@ bool Editor::find(QString query, bool caseSensitive, bool wholeWords)
     bool matchFound = QPlainTextEdit::find(query, searchOptions);
 
     // If we didn't find a match, search from the top of the document
-    if(!matchFound)
+    if (!matchFound)
     {
         moveCursor(QTextCursor::Start);
         matchFound = QPlainTextEdit::find(query, searchOptions);
     }
 
     // If we found a match...
-    if(matchFound)
+    if (matchFound)
     {
         int foundPosition = textCursor().position();
         bool previouslyFound = searchHistory.previouslyFound(query);
 
         // If it's the first time finding this, log the first position at which this query was found in the current document state
         // Search history is always reset whenever we do a full cycle back to the first match or start a new search "chain"
-        if(!previouslyFound)
+        if (!previouslyFound)
         {
             searchHistory.add(query, cursorPositionBeforeCurrentSearch, foundPosition);
         }
@@ -202,7 +202,7 @@ bool Editor::find(QString query, bool caseSensitive, bool wholeWords)
         {
             bool loopedBackToFirstMatch = foundPosition == searchHistory.firstFoundAt(query);
 
-            if(loopedBackToFirstMatch)
+            if (loopedBackToFirstMatch)
             {
                 // It's not really a match that we found; it's a repeat of the very first-ever match
                 matchFound = false;
@@ -242,7 +242,7 @@ void Editor::replace(QString what, QString with, bool caseSensitive, bool wholeW
 {
     bool found = find(what, caseSensitive, wholeWords);
 
-    if(found)
+    if (found)
     {
         QTextCursor cursor = textCursor();
         cursor.beginEditBlock();
@@ -275,7 +275,7 @@ void Editor::replaceAll(QString what, QString with, bool caseSensitive, bool who
     // Keep replacing while there are matches left
     QTextCursor cursor(document());
     cursor.beginEditBlock();
-    while(found)
+    while (found)
     {
         QTextCursor currentPosition = textCursor();
         currentPosition.insertText(with);
@@ -285,7 +285,7 @@ void Editor::replaceAll(QString what, QString with, bool caseSensitive, bool who
     cursor.endEditBlock();
 
     // End-of-operation feedback
-    if(replacements == 0)
+    if (replacements == 0)
     {
         emit(findResultReady("No results found."));
     }
@@ -306,7 +306,7 @@ void Editor::replaceAll(QString what, QString with, bool caseSensitive, bool who
  */
 void Editor::goTo(int line)
 {
-    if(line > blockCount() || line < 1)
+    if (line > blockCount() || line < 1)
     {
         emit(gotoResultReady("Invalid line number."));
         return;
@@ -330,7 +330,7 @@ void Editor::formatSubtext(int startIndex, int endIndex, QTextCharFormat format,
     QTextCursor cursorBeforeFormatting = textCursor();
     QTextCursor formatter = textCursor();
 
-    if(unformatAllFirst)
+    if (unformatAllFirst)
     {
         QTextCursor unformatter = textCursor();
         unformatter.setPosition(0, QTextCursor::MoveAnchor);
@@ -374,7 +374,7 @@ void Editor::toggleAutoIndent(bool autoIndent)
  */
 void Editor::toggleWrapMode(bool wrap)
 {
-    if(wrap)
+    if (wrap)
     {
         setLineWrapMode(LineWrapMode::WidgetWidth);
     }
@@ -410,16 +410,16 @@ void Editor::updateWordCount()
     int documentLength = documentContents.length();
     QString currentWord = "";
 
-    for(int i = 0; i < documentLength; i++)
+    for (int i = 0; i < documentLength; i++)
     {
         // Convert to unsigned char to avoid running into debug assertion problems
         unsigned char character = qvariant_cast<unsigned char>(documentContents[i].toLatin1());
 
         // Newline
-        if(character == '\n')
+        if (character == '\n')
         {
             // Special case: newline following a word
-            if(!currentWord.isEmpty())
+            if (!currentWord.isEmpty())
             {
                 metrics.wordCount++;
                 currentWord.clear();
@@ -429,15 +429,15 @@ void Editor::updateWordCount()
         else
         {
             // Alphanumeric character
-            if(isalnum(character))
+            if (isalnum(character))
             {
                 currentWord += qvariant_cast<char>(character);
             }
             // Whitespace (excluding newline, handled separately above)
-            else if(isspace(character))
+            else if (isspace(character))
             {
                 // Whitespace following a word means we completed a word
-                if(!currentWord.isEmpty())
+                if (!currentWord.isEmpty())
                 {
                     metrics.wordCount++;
                     currentWord.clear();
@@ -447,7 +447,7 @@ void Editor::updateWordCount()
     }
 
     // e.g., if we stopped typing and still had a word in progress, we need to count it
-    if(!currentWord.isEmpty())
+    if (!currentWord.isEmpty())
     {
         metrics.wordCount++;
         currentWord.clear();
@@ -477,14 +477,14 @@ int Editor::indentationLevelOfCurrentLine()
     int indentationLevel = 0;
 
     int index = textCursor().position();
-    if(index >= documentContents.length())
+    if (index >= documentContents.length())
     {
         index--;
     }
 
-    while(index < documentContents.length())
+    while (index < documentContents.length())
     {
-        if(documentContents.at(index) == '\t')
+        if (documentContents.at(index) == '\t')
         {
             indentationLevel++;
             index++;
@@ -504,7 +504,7 @@ int Editor::indentationLevelOfCurrentLine()
  */
 void Editor::insertTabs(int numTabs)
 {
-    for(int i = 0; i < numTabs; i++)
+    for (int i = 0; i < numTabs; i++)
     {
         insertPlainText("\t");
     }
@@ -522,7 +522,7 @@ void Editor::moveCursorToStartOfCurrentLine()
         cursor.movePosition(QTextCursor::Left);
         setTextCursor(cursor);
     }
-    while(metrics.currentColumn != 1);
+    while (metrics.currentColumn != 1);
 }
 
 
@@ -534,10 +534,10 @@ void Editor::indentSelection(QTextDocumentFragment selection)
     QString text = selection.toPlainText();
 
     text.insert(0, '\t');
-    for(int i = 1; i < text.length(); i++)
+    for (int i = 1; i < text.length(); i++)
     {
         // Insert a tab after each newline
-        if(text.at(i) == '\n' && i + 1 < text.length())
+        if (text.at(i) == '\n' && i + 1 < text.length())
         {
             text.insert(i + 1, '\t');
         }
@@ -581,7 +581,7 @@ bool Editor::handleEnterKeyPress()
         QChar codeBlockEndDelimiter = syntaxHighlighter->getCodeBlockEndDelimiter();
 
         insertPlainText("\n");
-        if(autoIndentEnabled)
+        if (autoIndentEnabled)
         {
             insertTabs(currentIndent + 1);
         }
@@ -621,7 +621,7 @@ bool Editor::handleEnterKeyPress()
  */
 bool Editor::handleTabKeyPress()
 {
-    if(textCursor().hasSelection())
+    if (textCursor().hasSelection())
     {
         indentSelection(textCursor().selection());
         return true;
@@ -636,15 +636,15 @@ bool Editor::handleTabKeyPress()
  */
 bool Editor::eventFilter(QObject* obj, QEvent* event)
 {
-    if(event->type() == QEvent::KeyPress)
+    if (event->type() == QEvent::KeyPress)
     {
         int key = static_cast<QKeyEvent*>(event)->key();
 
-        if(key == Qt::Key_Enter || key == Qt::Key_Return)
+        if (key == Qt::Key_Enter || key == Qt::Key_Return)
         {
             return handleEnterKeyPress();
         }
-        else if(key == Qt::Key_Tab)
+        else if (key == Qt::Key_Tab)
         {
             return handleTabKeyPress();
         }
@@ -721,7 +721,7 @@ void Editor::updateLineNumberAreaWidth()
  */
 void Editor::redrawLineNumberArea(const QRect &rectToBeRedrawn, int numPixelsScrolledVertically)
 {
-    if(numPixelsScrolledVertically != 0)
+    if (numPixelsScrolledVertically != 0)
     {
         lineNumberArea->scroll(0, numPixelsScrolledVertically);
     }
@@ -730,7 +730,7 @@ void Editor::redrawLineNumberArea(const QRect &rectToBeRedrawn, int numPixelsScr
         lineNumberArea->update(0, rectToBeRedrawn.y(), lineNumberArea->width(), rectToBeRedrawn.height());
     }
 
-    if(rectToBeRedrawn.contains(viewport()->rect()))
+    if (rectToBeRedrawn.contains(viewport()->rect()))
     {
         updateLineNumberAreaWidth();
     }

--- a/CustomTextEditor/finddialog.cpp
+++ b/CustomTextEditor/finddialog.cpp
@@ -95,7 +95,7 @@ void FindDialog::on_findNextButton_clicked()
 {
     QString query = findLineEdit->text();
 
-    if(query.isEmpty())
+    if (query.isEmpty())
     {
         QMessageBox::information(this, tr("Empty Field"), tr("Please enter a query."));
         return;
@@ -115,7 +115,7 @@ void FindDialog::on_replaceOperation_initiated()
 {
     QString what = findLineEdit->text();
 
-    if(what.isEmpty())
+    if (what.isEmpty())
     {
         QMessageBox::information(this, tr("Empty Field"), tr("Please enter a query."));
         return;
@@ -126,7 +126,7 @@ void FindDialog::on_replaceOperation_initiated()
     bool wholeWords = wholeWordsCheckBox->isChecked();
     bool replace = sender() == replaceButton;
 
-    if(replace)
+    if (replace)
     {
         emit(startReplacing(what, with, caseSensitive, wholeWords));
     }

--- a/CustomTextEditor/gotodialog.cpp
+++ b/CustomTextEditor/gotodialog.cpp
@@ -42,7 +42,7 @@ void GotoDialog::on_gotoButton_clicked()
 {
     QString line = gotoLineEdit->text();
 
-    if(line.isEmpty())
+    if (line.isEmpty())
     {
         QMessageBox::information(this, tr("Go"), tr("Must enter a line number."));
         return;

--- a/CustomTextEditor/highlighters/chighlighter.cpp
+++ b/CustomTextEditor/highlighters/chighlighter.cpp
@@ -20,4 +20,7 @@ CHighlighter::CHighlighter(QTextDocument *parent) : Highlighter(parent)
 
     blockCommentStart = QRegularExpression("/\\*");
     blockCommentEnd = QRegularExpression("\\*/");
+
+    codeBlockStart = '{';
+    codeBlockEnd = '}';
 }

--- a/CustomTextEditor/highlighters/highlighter.cpp
+++ b/CustomTextEditor/highlighters/highlighter.cpp
@@ -50,7 +50,7 @@ void Highlighter::highlightBlock(const QString &text)
     {
         QRegularExpressionMatchIterator iterator = rule.pattern.globalMatch(text);
 
-        while(iterator.hasNext())
+        while (iterator.hasNext())
         {
             QRegularExpressionMatch match = iterator.next();
             setFormat(match.capturedStart(), match.capturedLength(), rule.format);
@@ -70,7 +70,7 @@ void Highlighter::highlightMultilineComments(const QString &text)
     int startIndex = 0;
 
     // If the previous state was not in comment, then start searching from very beginning
-    if(previousBlockState() != BlockState::InComment)
+    if (previousBlockState() != BlockState::InComment)
     {
         startIndex = text.indexOf(blockCommentStart);
     }

--- a/CustomTextEditor/highlighters/highlighter.h
+++ b/CustomTextEditor/highlighters/highlighter.h
@@ -15,6 +15,9 @@ public:
     virtual void addKeywords(QStringList keywords);
     virtual void addRule(QRegularExpression pattern, QTextCharFormat format);
 
+    QChar getCodeBlockStartDelimiter() const { return codeBlockStart; }
+    QChar getCodeBlockEndDelimiter() const { return codeBlockEnd; }
+
 protected:
 
     virtual void highlightBlock(const QString &text) override;
@@ -39,12 +42,17 @@ protected:
     QRegularExpression blockCommentStart;
     QRegularExpression blockCommentEnd;
 
+    // For auto-indentation after a user hits ENTER
+    QChar codeBlockStart;
+    QChar codeBlockEnd;
+
     QTextCharFormat keywordFormat;
     QTextCharFormat classFormat;
     QTextCharFormat inlineCommentFormat;
     QTextCharFormat blockCommentFormat;
     QTextCharFormat quoteFormat;
     QTextCharFormat functionFormat;
+
 };
 
 #endif // HIGHLIGHTER_H

--- a/CustomTextEditor/highlighters/javahighlighter.cpp
+++ b/CustomTextEditor/highlighters/javahighlighter.cpp
@@ -22,4 +22,7 @@ JavaHighlighter::JavaHighlighter(QTextDocument *parent) : Highlighter (parent)
 
     blockCommentStart = QRegularExpression("/\\*");
     blockCommentEnd = QRegularExpression("\\*/");
+
+    codeBlockStart = '{';
+    codeBlockEnd = '}';
 }

--- a/CustomTextEditor/highlighters/pythonhighlighter.cpp
+++ b/CustomTextEditor/highlighters/pythonhighlighter.cpp
@@ -22,6 +22,9 @@ PythonHighlighter::PythonHighlighter(QTextDocument *parent) : Highlighter(parent
     triple_single_quote.second = MultilineQuote::TRIPLE_SINGLE;
     triple_double_quote.first = QRegularExpression("\"\"\"");
     triple_double_quote.second = MultilineQuote::TRIPLE_DOUBLE;
+
+    codeBlockStart = ':';
+    codeBlockEnd = NULL;
 }
 
 

--- a/CustomTextEditor/highlighters/pythonhighlighter.cpp
+++ b/CustomTextEditor/highlighters/pythonhighlighter.cpp
@@ -35,7 +35,7 @@ void PythonHighlighter::highlightBlock(const QString &text)
     {
         QRegularExpressionMatchIterator iterator = rule.pattern.globalMatch(text);
 
-        while(iterator.hasNext())
+        while (iterator.hasNext())
         {
             QRegularExpressionMatch match = iterator.next();
             setFormat(match.capturedStart(), match.capturedLength(), rule.format);
@@ -45,7 +45,7 @@ void PythonHighlighter::highlightBlock(const QString &text)
     setCurrentBlockState(BlockState::NotInComment);
 
     // Handle multiline comments
-    if(!highlightMultilineComments(text, triple_single_quote.first, triple_single_quote.second))
+    if (!highlightMultilineComments(text, triple_single_quote.first, triple_single_quote.second))
     {
         highlightMultilineComments(text, triple_double_quote.first, triple_double_quote.second);
     }
@@ -57,7 +57,7 @@ bool PythonHighlighter::highlightMultilineComments(const QString &text, QRegular
     int startIndex = 0;
     int offset = 0;
 
-    if(previousBlockState() != in_state)
+    if (previousBlockState() != in_state)
     {
         startIndex = text.indexOf(pattern);
         offset = pattern.match(text).capturedLength();
@@ -69,7 +69,7 @@ bool PythonHighlighter::highlightMultilineComments(const QString &text, QRegular
         int endIndex = match.capturedStart();
         int commentLength = 0;
 
-        if(endIndex >= offset)
+        if (endIndex >= offset)
         {
             commentLength = endIndex - startIndex + offset + pattern.match(text).capturedLength();
             setCurrentBlockState(BlockState::NotInComment);

--- a/CustomTextEditor/language.cpp
+++ b/CustomTextEditor/language.cpp
@@ -5,13 +5,13 @@ QString ProgrammingLanguage::toString(Language language)
 {
     switch (language)
     {
-        case(Language::C):
+        case (Language::C):
             return "Language: C";
-        case(Language::CPP):
+        case (Language::CPP):
             return "Language: C++";
-        case(Language::Java):
+        case (Language::Java):
             return "Language: Java";
-        case(Language::Python):
+        case (Language::Python):
             return "Language: Python";
         default:
             return "Language not selected";

--- a/CustomTextEditor/mainwindow.cpp
+++ b/CustomTextEditor/mainwindow.cpp
@@ -158,31 +158,31 @@ void MainWindow::on_languageSelected(QAction* languageAction)
  */
 void MainWindow::triggerCorrespondingMenuLanguageOption(Language lang)
 {
-    switch(lang)
+    switch (lang)
     {
-        case(Language::C):
-            if(!ui->actionC_Lang->isChecked())
+        case (Language::C):
+            if (!ui->actionC_Lang->isChecked())
             {
                 ui->actionC_Lang->trigger();
             }
             break;
 
-        case(Language::CPP):
-            if(!ui->actionCPP_Lang->isChecked())
+        case (Language::CPP):
+            if (!ui->actionCPP_Lang->isChecked())
             {
                 ui->actionCPP_Lang->trigger();
             }
             break;
 
-        case(Language::Java):
-            if(!ui->actionJava_Lang->isChecked())
+        case (Language::Java):
+            if (!ui->actionJava_Lang->isChecked())
             {
                 ui->actionJava_Lang->trigger();
             }
             break;
 
-        case(Language::Python):
-            if(!ui->actionPython_Lang->isChecked())
+        case (Language::Python):
+            if (!ui->actionPython_Lang->isChecked())
             {
                 ui->actionPython_Lang->trigger();
             }
@@ -202,7 +202,7 @@ void MainWindow::setLanguageFromExtension()
     QString fileName = editor->getFileName();
     int indexOfDot = fileName.indexOf('.');
 
-    if(indexOfDot == -1)
+    if (indexOfDot == -1)
     {
         selectProgrammingLanguage(Language::None);
         return;
@@ -212,7 +212,7 @@ void MainWindow::setLanguageFromExtension()
 
     bool extensionSupported = extensionToLanguageMap.find(fileExtension) != extensionToLanguageMap.end();
 
-    if(!extensionSupported)
+    if (!extensionSupported)
     {
         selectProgrammingLanguage(Language::None);
         return;
@@ -227,7 +227,7 @@ void MainWindow::setLanguageFromExtension()
  */
 void MainWindow::selectProgrammingLanguage(Language language)
 {
-    if(language == editor->getProgrammingLanguage())
+    if (language == editor->getProgrammingLanguage())
     {
         return;
     }
@@ -292,13 +292,13 @@ void MainWindow::reconnectEditorDependentSignals()
 void MainWindow::on_currentTabChanged(int index)
 {
     // Happens when the tabbed editor's last tab is closed
-    if(index == -1)
+    if (index == -1)
     {
         return;
     }
 
     // Note: editor will only be nullptr on the first launch, so this will get skipped in that edge case
-    if(editor != nullptr)
+    if (editor != nullptr)
     {
         disconnectEditorDependentSignals();
     }
@@ -310,14 +310,14 @@ void MainWindow::on_currentTabChanged(int index)
     Language tabLanguage = editor->getProgrammingLanguage();
 
     // If this tab had a programming language set, trigger the corresponding option
-    if(tabLanguage != Language::None)
+    if (tabLanguage != Language::None)
     {
         triggerCorrespondingMenuLanguageOption(tabLanguage);
     }
     else
     {        
         // If a menu language is checked but the current tab has no language set, uncheck the menu option
-        if(languageGroup->checkedAction())
+        if (languageGroup->checkedAction())
         {
             languageGroup->checkedAction()->setChecked(false);
         }
@@ -348,7 +348,7 @@ void MainWindow::on_currentTabChanged(int index)
  */
 void MainWindow::launchFindDialog()
 {
-    if(findDialog->isHidden())
+    if (findDialog->isHidden())
     {
         findDialog->show();
         findDialog->activateWindow();
@@ -362,7 +362,7 @@ void MainWindow::launchFindDialog()
  */
 void MainWindow::launchGotoDialog()
 {
-    if(gotoDialog->isHidden())
+    if (gotoDialog->isHidden())
     {
         gotoDialog->show();
         gotoDialog->activateWindow();
@@ -380,7 +380,7 @@ void MainWindow::updateTabAndWindowTitle()
     QString tabTitle = editor->getFileName();
     QString windowTitle = tabTitle;
 
-    if(editor->isUnsaved())
+    if (editor->isUnsaved())
     {
         tabTitle += " *";
         windowTitle += " [Unsaved]";
@@ -424,7 +424,7 @@ bool MainWindow::on_actionSaveTriggered()
     QString currentFilePath = editor->getCurrentFilePath();
 
     // If user hit Save As or user hit Save but current document was never saved to disk
-    if(saveAs || currentFilePath.isEmpty())
+    if (saveAs || currentFilePath.isEmpty())
     {
         // Title to be used for saving dialog
         QString saveDialogWindowTitle = saveAs ? tr("Save As") : tr("Save");
@@ -433,7 +433,7 @@ bool MainWindow::on_actionSaveTriggered()
         QString filePath = QFileDialog::getSaveFileName(this, saveDialogWindowTitle);
 
         // Don't do anything if the user changes their mind and hits Cancel
-        if(filePath.isNull())
+        if (filePath.isNull())
         {
             return false;
         }
@@ -478,7 +478,7 @@ void MainWindow::on_actionOpen_triggered()
     QString openedFilePath;
     QString lastUsedDirectory = settings->value(DEFAULT_DIRECTORY_KEY).toString();
 
-    if(lastUsedDirectory.isEmpty())
+    if (lastUsedDirectory.isEmpty())
     {
         openedFilePath = QFileDialog::getOpenFileName(this, tr("Open"), DEFAULT_DIRECTORY);
     }
@@ -488,7 +488,7 @@ void MainWindow::on_actionOpen_triggered()
     }
 
     // Don't do anything if the user hit Cancel
-    if(openedFilePath.isNull())
+    if (openedFilePath.isNull())
     {
         return;
     }
@@ -509,7 +509,7 @@ void MainWindow::on_actionOpen_triggered()
     QTextStream in(&file);
     QString documentContents = in.readAll();
 
-    if(!openInCurrentTab)
+    if (!openInCurrentTab)
     {
         tabbedEditor->add(new Editor());
     }
@@ -532,7 +532,7 @@ void MainWindow::on_actionPrint_triggered()
     printer.setPrinterName(tr("Document printer"));
     QPrintDialog printDialog(&printer, this);
 
-    if(printDialog.exec() != QPrintDialog::Rejected)
+    if (printDialog.exec() != QPrintDialog::Rejected)
     {
         editor->print(&printer);
         ui->statusBar->showMessage("Printing", 2000);
@@ -550,27 +550,27 @@ bool MainWindow::closeTab(Editor *tabToClose)
     bool closingCurrentTab = (tabToClose == currentTab);
 
     // Allow the user to see what tab they're closing if it's not the current one
-    if(!closingCurrentTab)
+    if (!closingCurrentTab)
     {
         tabbedEditor->setCurrentWidget(tabToClose);
     }
 
     // Don't close a tab immediately if it has unsaved contents
-    if(tabToClose->isUnsaved())
+    if (tabToClose->isUnsaved())
     {
         QMessageBox::StandardButton selection = askUserToSave();
 
-        if(selection == QMessageBox::StandardButton::Yes)
+        if (selection == QMessageBox::StandardButton::Yes)
         {
             bool fileSaved = on_actionSaveTriggered();
 
-            if(!fileSaved)
+            if (!fileSaved)
             {
                 return false;
             }
         }
 
-        else if(selection == QMessageBox::Cancel)
+        else if (selection == QMessageBox::Cancel)
         {
             return false;
         }
@@ -580,13 +580,13 @@ bool MainWindow::closeTab(Editor *tabToClose)
     tabbedEditor->removeTab(indexOfTabToClose);
 
     // If we closed the last tab, make a new one
-    if(tabbedEditor->count() == 0)
+    if (tabbedEditor->count() == 0)
     {
         on_actionNew_triggered();
     }
 
     // And finally, go back to original tab if the user was closing a different one
-    if(!closingCurrentTab)
+    if (!closingCurrentTab)
     {
         tabbedEditor->setCurrentWidget(currentTab);
     }
@@ -602,11 +602,11 @@ void MainWindow::on_actionExit_triggered()
 {
     QVector<Editor*> unsavedTabs = tabbedEditor->unsavedTabs();
 
-    for(Editor *tab : unsavedTabs)
+    for (Editor *tab : unsavedTabs)
     {
         bool userClosedTab = closeTab(tab);
 
-        if(!userClosedTab)
+        if (!userClosedTab)
         {
             return;
         }
@@ -674,7 +674,7 @@ void MainWindow::toggleRedo(bool redoAvailable)
  */
 void MainWindow::on_actionUndo_triggered()
 {
-    if(ui->actionUndo->isEnabled())
+    if (ui->actionUndo->isEnabled())
     {
         editor->undo();
     }
@@ -685,7 +685,7 @@ void MainWindow::on_actionUndo_triggered()
  */
 void MainWindow::on_actionRedo_triggered()
 {
-    if(ui->actionRedo->isEnabled())
+    if (ui->actionRedo->isEnabled())
     {
         editor->redo();
     }
@@ -705,7 +705,7 @@ void MainWindow::toggleCopyAndCut(bool copyCutAvailable)
  */
 void MainWindow::on_actionCut_triggered()
 {
-    if(ui->actionCut->isEnabled())
+    if (ui->actionCut->isEnabled())
     {
         editor->cut();
     }
@@ -716,7 +716,7 @@ void MainWindow::on_actionCut_triggered()
  */
 void MainWindow::on_actionCopy_triggered()
 {
-    if(ui->actionCopy->isEnabled())
+    if (ui->actionCopy->isEnabled())
     {
         editor->copy();
     }
@@ -782,7 +782,7 @@ void MainWindow::on_actionAuto_Indent_triggered()
     bool autoIndentToggled = tabbedEditor->applyAutoIndentation(shouldAutoIndent);
 
     // If the user canceled the operation, reverse the checking
-    if(!autoIndentToggled)
+    if (!autoIndentToggled)
     {
         ui->actionAuto_Indent->setChecked(!shouldAutoIndent);
     }

--- a/CustomTextEditor/searchhistory.cpp
+++ b/CustomTextEditor/searchhistory.cpp
@@ -8,7 +8,7 @@
 void SearchHistory::add(QString term, int cursorPositionBeforeFirstSearch, int firstFoundAt)
 {
     // If this search term breaks the current search "chain", clear the history
-    if(!previouslyFound(term))
+    if (!previouslyFound(term))
     {
         searchHistory.clear();
     }

--- a/CustomTextEditor/settings.cpp
+++ b/CustomTextEditor/settings.cpp
@@ -32,7 +32,7 @@ QVariant Settings::value(const QString &key, const QVariant &defaultValue)
  */
 void Settings::apply(QVariant setting, std::function<void(QVariant)> handler)
 {
-    if(!setting.isNull())
+    if (!setting.isNull())
     {
         handler(setting);
     }

--- a/CustomTextEditor/tabbededitor.cpp
+++ b/CustomTextEditor/tabbededitor.cpp
@@ -37,7 +37,7 @@ Editor* TabbedEditor::currentTab() const
  */
 Editor* TabbedEditor::tabAt(int index) const
 {
-    if(index < 0 || index >= count())
+    if (index < 0 || index >= count())
     {
         return nullptr;
     }
@@ -52,7 +52,7 @@ QVector<Editor*> TabbedEditor::tabs() const
 {
     QVector<Editor*> tabs;
 
-    for(int i = 0; i < count(); i++)
+    for (int i = 0; i < count(); i++)
     {
         tabs.push_back(tabAt(i));
     }
@@ -67,11 +67,11 @@ QVector<Editor*> TabbedEditor::unsavedTabs() const
 {
     QVector<Editor*> unsavedTabs;
 
-    for(int i = 0; i < count(); i++)
+    for (int i = 0; i < count(); i++)
     {
         Editor *tab = tabAt(i);
 
-        if(tab->isUnsaved())
+        if (tab->isUnsaved())
         {
             unsavedTabs.push_back(tab);
         }
@@ -88,13 +88,13 @@ void TabbedEditor::promptFontSelection()
     bool userChoseFont;
     QFont newFont = QFontDialog::getFont(&userChoseFont, currentTab()->getFont(), this);
 
-    if(!userChoseFont) return;
+    if (!userChoseFont) return;
 
     QMessageBox::StandardButton tabSelection = Utility::promptYesOrNo(this, tr("Font change"),
                                                                       tr("Apply to all open and future tabs?"));
 
     // Apply font to all tabs
-    if(tabSelection == QMessageBox::Yes)
+    if (tabSelection == QMessageBox::Yes)
     {
         for (Editor *tab : tabs())
         {
@@ -103,7 +103,7 @@ void TabbedEditor::promptFontSelection()
     }
 
     // Apply font only to current tab
-    else if(tabSelection == QMessageBox::No)
+    else if (tabSelection == QMessageBox::No)
     {
         currentTab()->setFont(newFont, QFont::Monospace, true, Editor::NUM_CHARS_FOR_TAB);
     }
@@ -131,7 +131,7 @@ bool TabbedEditor::applyWordWrapping(bool shouldWrap)
                                                                       tr("Apply to all tabs?"));
 
     // Apply wrapping to all tabs
-    if(tabSelection == QMessageBox::Yes)
+    if (tabSelection == QMessageBox::Yes)
     {
         for (Editor *tab : tabs())
         {
@@ -142,7 +142,7 @@ bool TabbedEditor::applyWordWrapping(bool shouldWrap)
     }
 
     // Apply wrapping only to current tab
-    else if(tabSelection == QMessageBox::No)
+    else if (tabSelection == QMessageBox::No)
     {
         currentTab()->toggleWrapMode(shouldWrap);
         return true;
@@ -172,7 +172,7 @@ bool TabbedEditor::applyAutoIndentation(bool shouldAutoIndent)
                                                                       tr("Apply to all open and future tabs?"));
 
     // Apply auto indentation to all tabs
-    if(tabSelection == QMessageBox::Yes)
+    if (tabSelection == QMessageBox::Yes)
     {
         for (Editor *tab : tabs())
         {
@@ -183,7 +183,7 @@ bool TabbedEditor::applyAutoIndentation(bool shouldAutoIndent)
     }
 
     // Apply auto indentation only to current tab
-    else if(tabSelection == QMessageBox::No)
+    else if (tabSelection == QMessageBox::No)
     {
         currentTab()->toggleAutoIndent(shouldAutoIndent);
         return true;
@@ -204,22 +204,22 @@ bool TabbedEditor::eventFilter(QObject* obj, QEvent* event)
 {
     bool isKeyPress = event->type() == QEvent::KeyPress;
 
-    if(isKeyPress)
+    if (isKeyPress)
     {
         QKeyEvent *keyInfo = static_cast<QKeyEvent*>(event);
         int key = keyInfo->key();
 
-        if(keyInfo->modifiers() == Qt::ControlModifier)
+        if (keyInfo->modifiers() == Qt::ControlModifier)
         {
             // Ctrl + num = jump to that tab number
-            if(key >= Qt::Key_1 && key <= Qt::Key_9)
+            if (key >= Qt::Key_1 && key <= Qt::Key_9)
             {
                 setCurrentWidget(tabAt(key - Qt::Key_1));
                 return true;
             }
 
             // Ctrl + tab = advance tab by one
-            else if(key == Qt::Key_T)
+            else if (key == Qt::Key_T)
             {
                 int newTabIndex = (currentIndex() + 1) % count();
                 setCurrentWidget(tabAt(newTabIndex));

--- a/CustomTextEditor/utilityfunctions.cpp
+++ b/CustomTextEditor/utilityfunctions.cpp
@@ -18,24 +18,24 @@ QMessageBox::StandardButton Utility::promptYesOrNo(QWidget *parent, QString titl
 /* Returns true if a closing brace must be inserted into the given string
  * to create a balanced expression and false otherwise.
  */
-bool Utility::closingBraceNeeded(QString context)
+bool Utility::codeBlockNotClosed(QString context, QChar startDelimiter, QChar endDelimiter)
 {
-    QStack<char> openingBraces;
+    QStack<char> codeBlockStartDelimiters;
 
     for (int i = 0; i < context.length(); i++)
     {
         char character = context.at(i).toLatin1();
 
-        if(character == '{')
+        if(character == startDelimiter)
         {
-            openingBraces.push(character);
+            codeBlockStartDelimiters.push(character);
         }
 
-        else if(character == '}' && !openingBraces.empty())
+        else if(character == endDelimiter && !codeBlockStartDelimiters.empty())
         {
-            openingBraces.pop();
+            codeBlockStartDelimiters.pop();
         }
     }
 
-    return !openingBraces.empty();
+    return !codeBlockStartDelimiters.empty();
 }

--- a/CustomTextEditor/utilityfunctions.cpp
+++ b/CustomTextEditor/utilityfunctions.cpp
@@ -26,12 +26,12 @@ bool Utility::codeBlockNotClosed(QString context, QChar startDelimiter, QChar en
     {
         char character = context.at(i).toLatin1();
 
-        if(character == startDelimiter)
+        if (character == startDelimiter)
         {
             codeBlockStartDelimiters.push(character);
         }
 
-        else if(character == endDelimiter && !codeBlockStartDelimiters.empty())
+        else if (character == endDelimiter && !codeBlockStartDelimiters.empty())
         {
             codeBlockStartDelimiters.pop();
         }

--- a/CustomTextEditor/utilityfunctions.h
+++ b/CustomTextEditor/utilityfunctions.h
@@ -7,7 +7,7 @@
 namespace Utility
 {
     QMessageBox::StandardButton promptYesOrNo(QWidget *parent, QString title, QString prompt);
-    bool closingBraceNeeded(QString context);
+    bool codeBlockNotClosed(QString context, QChar startDelimiter, QChar endDelimiter);
 }
 
 #endif // UTILITYFUNCTIONS_H


### PR DESCRIPTION
- Refactor auto-indentation logic to specify the code block start/end delimiters based on the currently active syntax highlighter. This makes it more flexible in case I decide to add support for other languages.

- Don't hug parentheses, for consistency and improved legibility.